### PR TITLE
feat: signal processing framework and batch CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,17 +560,68 @@ curl "http://localhost:8080/api/logs?diagnostic_severity=critical"
 
 CI (`diagnostics.yml`) validates all of this automatically on PRs that touch the diagnostics directory. Run `scripts/ci/check-analyzer.sh` locally to verify before pushing.
 
-## Signal Processing
+## For Researchers
 
-The signal processing framework provides a trait-based system for running analyses that need full time-series data (FFT, spectral analysis, deconvolution). Unlike diagnostics (which are streaming), signal processing modules declare what signals they need, the framework extracts them in a single ULog pass, and modules receive the buffered data.
+There are two paths for working with flight log data, depending on your tools and workflow.
 
-### Available Modules
+### Path 1: Parquet export for Python / ML workflows
+
+Convert ULog files to Parquet and work with them using your existing tools (polars, pandas, DuckDB, scikit-learn, PyTorch). The CLI handles all the ULog parsing and produces a self-describing dataset.
+
+```bash
+# Convert a directory of flight logs to Parquet
+ulog-convert batch logs/ -o dataset/ --diagnostics
+
+# Output structure:
+# dataset/
+# ├── index.json              ← entry point: lists all logs
+# ├── log_001/
+# │   ├── manifest.json       ← file map + diagnostic labels
+# │   ├── metadata.json       ← full flight metadata
+# │   ├── vehicle_attitude.parquet
+# │   ├── sensor_combined.parquet
+# │   └── ...
+# └── log_002/
+#     └── ...
+```
+
+From Python:
+
+```python
+import json, polars as pl
+
+# Load the dataset index
+with open("dataset/index.json") as f:
+    index = json.load(f)
+
+# Find logs with motor failures
+crashes = [log for log in index["logs"] if log["diagnostic_count"] > 0]
+
+# Load a specific topic as a dataframe
+df = pl.read_parquet(f"dataset/{crashes[0]['path']}/vehicle_attitude.parquet")
+```
+
+The diagnostic labels in each `manifest.json` provide pre-computed anomaly annotations with timestamps and severity -- usable as training labels for supervised learning without manually reviewing flights.
+
+### Path 2: Rust-native signal processing modules
+
+For analyses that need to run at scale across thousands of logs, or that you want to contribute back to the tool, write a Rust module that plugs into the signal processing framework. You declare what signals you need, the framework extracts them from the ULog file, and you receive buffered time-series data ready for FFT, spectral analysis, or deconvolution.
+
+```bash
+# Run signal processing on a single file
+ulog-convert analyze flight.ulg
+
+# Batch across a directory (parallel)
+ulog-convert batch logs/ --analyze -m pid_step_response
+```
+
+#### Available Modules
 
 | Module | Description | Topics |
 |--------|-------------|--------|
 | `pid_step_response` | PID controller step response via Wiener deconvolution | `vehicle_rates_setpoint`, `vehicle_angular_velocity` |
 
-### Adding a New Module
+#### Adding a New Module
 
 1. Create `crates/converter/src/signal_processing/your_module.rs`
 2. Implement the `SignalAnalysis` trait (`id`, `description`, `required_signals`, `analyze`)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,16 @@ Key technologies:
 
 ### CLI Tool (`ulog-convert`)
 
-`ulog-convert` is a standalone command-line tool for converting ULog files without running the server. It performs the same conversion, metadata extraction, analysis, and diagnostics as the server upload path but writes results to local files or stdout. Includes a `scan` subcommand for batch processing directories of ULog files with parallel analysis. No database dependencies -- purely file-based.
+`ulog-convert` is a standalone command-line tool for converting, diagnosing, and analyzing PX4 ULog files. No server, no database -- purely file-based. Designed for both individual file processing and batch workflows over entire flight log datasets.
+
+Key capabilities:
+
+- **Convert** ULog to per-topic Parquet files with metadata
+- **Diagnose** flight anomalies (motor failure, GPS interference, battery brownout, EKF failure, RC loss)
+- **Analyze** signal processing (PID step response via Wiener deconvolution)
+- **Batch process** directories of ULog files with parallel execution via rayon
+
+Every conversion produces a `manifest.json` that maps the output (source file, topics to Parquet paths, diagnostic results). Batch conversions additionally produce an `index.json` at the output root that indexes all converted logs.
 
 ### Two Paths
 
@@ -133,7 +142,8 @@ flight-review-rs/
 │   │   │   ├── metadata.rs     # All 13 ULog message types --> metadata.json
 │   │   │   ├── analysis.rs     # Flight modes, stats, battery, GPS, vibration, param diff
 │   │   │   ├── diagnostics/    # Diagnostic analyzers (motor, GPS, battery, EKF, RC)
-│   │   │   ├── pid_analysis.rs # Wiener deconvolution step response (roll/pitch/yaw)
+│   │   │   ├── signal_processing/ # Signal processing framework (PID step response, DSP)
+│   │   │   ├── pid_analysis.rs # Backward-compat facade for signal_processing
 │   │   │   └── bin/
 │   │   │       └── ulog_convert.rs
 │   │   ├── benches/            # Criterion benchmarks
@@ -432,32 +442,60 @@ Import database records, then pre-convert all logs in the background. Useful for
 `ulog-convert` is a standalone command-line tool for converting PX4 ULog files to Parquet and JSON. It can extract metadata, run flight analysis and diagnostics, perform PID step response analysis, and batch-scan directories for anomalies -- all without running the server or touching a database.
 
 ```bash
-# Full conversion (Parquet + metadata.json)
+# Single file conversion (produces Parquet + metadata.json + manifest.json)
 ulog-convert flight.ulg output_dir/
 
 # Metadata + diagnostics only (JSON to stdout)
 ulog-convert --metadata-only flight.ulg
 
-# PID step response analysis
-ulog-convert --pid-analysis flight.ulg
-
 # Compact JSON (for scripting)
 ulog-convert --metadata-only --output-format compact flight.ulg | jq .
 
-# List available diagnostic analyzers
-ulog-convert list-analyzers
+# Signal processing analysis
+ulog-convert analyze flight.ulg
+ulog-convert analyze flight.ulg -m pid_step_response
 
-# Batch scan a directory for anomalies (parallel, table output)
-ulog-convert scan data/files/ --diagnostics-only
+# Batch: convert a directory to Parquet (parallel, produces index.json)
+ulog-convert batch logs/ -o dataset/
 
-# Scan with JSON output for scripting
-ulog-convert scan data/files/ --diagnostics-only --output-format json
+# Batch: scan for anomalies
+ulog-convert batch logs/ --diagnostics-only
 
-# Scan with specific analyzer(s) only
-ulog-convert scan data/files/ -a gps_interference,ekf_failure
+# Batch: convert + diagnose + analyze
+ulog-convert batch logs/ -o dataset/ --diagnostics --analyze
 
-# Version
-ulog-convert --version
+# Batch: filter to specific analyzers
+ulog-convert batch logs/ --diagnostics-only --analyzer gps_interference,ekf_failure
+
+# JSON output for scripting
+ulog-convert batch logs/ --diagnostics-only --format json
+```
+
+### Conversion Output
+
+Every conversion produces a self-describing output directory:
+
+```
+output/
+├── manifest.json              # what's here: source, topics, file map, diagnostics
+├── metadata.json              # full flight metadata and analysis
+├── vehicle_attitude.parquet   # one Parquet file per ULog topic
+├── sensor_combined.parquet
+└── ...
+```
+
+Batch conversions add an `index.json` at the output root:
+
+```
+dataset/
+├── index.json                 # indexes all logs with manifest paths
+├── sample/
+│   ├── manifest.json
+│   ├── metadata.json
+│   └── *.parquet
+├── motor_failure/
+│   ├── manifest.json
+│   └── ...
 ```
 
 ## Upload Context Fields
@@ -521,6 +559,26 @@ curl "http://localhost:8080/api/logs?diagnostic_severity=critical"
 7. Run `cargo bench` and include results in the PR
 
 CI (`diagnostics.yml`) validates all of this automatically on PRs that touch the diagnostics directory. Run `scripts/ci/check-analyzer.sh` locally to verify before pushing.
+
+## Signal Processing
+
+The signal processing framework provides a trait-based system for running analyses that need full time-series data (FFT, spectral analysis, deconvolution). Unlike diagnostics (which are streaming), signal processing modules declare what signals they need, the framework extracts them in a single ULog pass, and modules receive the buffered data.
+
+### Available Modules
+
+| Module | Description | Topics |
+|--------|-------------|--------|
+| `pid_step_response` | PID controller step response via Wiener deconvolution | `vehicle_rates_setpoint`, `vehicle_angular_velocity` |
+
+### Adding a New Module
+
+1. Create `crates/converter/src/signal_processing/your_module.rs`
+2. Implement the `SignalAnalysis` trait (`id`, `description`, `required_signals`, `analyze`)
+3. Register in `create_analyses()` in `signal_processing/mod.rs`
+4. Use shared DSP utilities from `signal_processing/dsp.rs` (resampling, windowing, sample rate estimation)
+5. Add tests following the pattern in `signal_processing/testing.rs`
+
+Shared DSP functions available in `dsp.rs`: `median_sample_rate`, `resample_uniform`, `hanning_window`.
 
 ## Roadmap
 

--- a/crates/converter/src/bin/ulog_convert.rs
+++ b/crates/converter/src/bin/ulog_convert.rs
@@ -12,7 +12,7 @@ enum OutputFormat {
 }
 
 #[derive(Debug, Clone, ValueEnum)]
-enum ScanFormat {
+enum BatchFormat {
     /// Human-readable summary table (default)
     Table,
     /// One JSON object per file, one per line
@@ -22,7 +22,7 @@ enum ScanFormat {
 }
 
 #[derive(Parser)]
-#[command(name = "ulog-convert", version, about = "Convert ULog files to Parquet + metadata")]
+#[command(name = "ulog-convert", version, about = "Convert and analyze PX4 ULog files")]
 struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
@@ -48,32 +48,51 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
-    /// List available diagnostic analyzers
-    ListAnalyzers,
+    /// List available diagnostic analyzers and signal processing modules
+    List,
 
-    /// Scan a directory of ULog files for diagnostics
-    Scan {
+    /// Batch process a directory of ULog files
+    ///
+    /// Convert, diagnose, and analyze ULog files in parallel.
+    /// By default converts to Parquet + metadata.json.
+    Batch {
         /// Directory containing .ulg files (searched recursively)
         path: String,
 
-        /// Only show logs that have diagnostics
+        /// Output directory for Parquet + metadata (omit to skip conversion)
+        #[arg(long, short)]
+        output: Option<String>,
+
+        /// Run diagnostic analyzers
+        #[arg(long)]
+        diagnostics: bool,
+
+        /// Only show logs that have diagnostics (implies --diagnostics)
         #[arg(long)]
         diagnostics_only: bool,
 
-        /// Run only specific analyzer(s), comma-separated
-        #[arg(long, short, value_delimiter = ',')]
+        /// Filter to specific diagnostic analyzer(s), comma-separated
+        #[arg(long, value_delimiter = ',')]
         analyzer: Vec<String>,
+
+        /// Run signal processing analyses
+        #[arg(long)]
+        analyze: bool,
+
+        /// Filter to specific analysis module(s), comma-separated
+        #[arg(long, value_delimiter = ',')]
+        modules: Vec<String>,
 
         /// Number of parallel workers (default: num CPUs)
         #[arg(long, short)]
         jobs: Option<usize>,
 
-        /// Output format: table, json, or json-pretty
-        #[arg(long, value_enum, default_value_t = ScanFormat::Table)]
-        output_format: ScanFormat,
+        /// Output format for results: table, json, or json-pretty
+        #[arg(long, value_enum, default_value_t = BatchFormat::Table)]
+        format: BatchFormat,
     },
 
-    /// Run signal processing analyses on a ULog file
+    /// Run signal processing analyses on a single ULog file
     Analyze {
         /// Input ULog file (required unless --list)
         file: Option<String>,
@@ -106,12 +125,20 @@ fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-        Some(Command::ListAnalyzers) => {
+        Some(Command::List) => {
+            println!("Diagnostic analyzers:");
+            println!();
             let analyzers = flight_review::diagnostics::create_analyzers();
             for a in &analyzers {
-                println!("{:<20} {}", a.id(), a.description());
-                println!("{:<20} topics: {}", "", a.required_topics().join(", "));
-                println!();
+                println!("  {:<24} {}", a.id(), a.description());
+            }
+
+            println!();
+            println!("Signal processing modules:");
+            println!();
+            let analyses = flight_review::signal_processing::create_analyses();
+            for a in &analyses {
+                println!("  {:<24} {}", a.id(), a.description());
             }
             return;
         }
@@ -126,12 +153,10 @@ fn main() {
                 for a in &analyses {
                     println!("{:<24} {}", a.id(), a.description());
                     let signals = a.required_signals();
-                    let topics: Vec<String> = {
-                        let mut t: Vec<&str> = signals.iter().map(|s| s.topic.as_str()).collect();
-                        t.sort();
-                        t.dedup();
-                        t.into_iter().map(String::from).collect()
-                    };
+                    let mut topics: Vec<&str> =
+                        signals.iter().map(|s| s.topic.as_str()).collect();
+                    topics.sort();
+                    topics.dedup();
                     println!("{:<24} topics: {}", "", topics.join(", "));
                     println!();
                 }
@@ -152,54 +177,97 @@ fn main() {
                 match flight_review::signal_processing::create_analyses_filtered(&modules) {
                     Ok(a) => a,
                     Err(e) => {
-                        eprintln!("error: {}", e);
+                        eprintln!("error: {e}");
                         std::process::exit(1);
                     }
                 }
             };
 
-            let results =
-                match flight_review::signal_processing::run_analyses(&file, &analyses) {
-                    Ok(r) => r,
-                    Err(e) => {
-                        eprintln!("error: {}", e);
-                        std::process::exit(1);
-                    }
-                };
-
-            let json = match output_format {
-                OutputFormat::Pretty => serde_json::to_string_pretty(&results).unwrap(),
-                OutputFormat::Compact => serde_json::to_string(&results).unwrap(),
-            };
-            println!("{}", json);
-            return;
-        }
-        Some(Command::Scan {
-            path,
-            diagnostics_only,
-            analyzer,
-            jobs,
-            output_format,
-        }) => {
-            // Validate analyzer IDs upfront
-            if !analyzer.is_empty() {
-                if let Err(e) = flight_review::diagnostics::create_analyzers_filtered(&analyzer) {
-                    eprintln!("error: {}", e);
+            match flight_review::signal_processing::run_analyses(&file, &analyses) {
+                Ok(results) => {
+                    let json = match output_format {
+                        OutputFormat::Pretty => serde_json::to_string_pretty(&results).unwrap(),
+                        OutputFormat::Compact => serde_json::to_string(&results).unwrap(),
+                    };
+                    println!("{json}");
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
                     std::process::exit(1);
                 }
             }
-            run_scan(&path, diagnostics_only, &analyzer, jobs, &output_format);
+            return;
+        }
+        Some(Command::Batch {
+            path,
+            output,
+            diagnostics,
+            diagnostics_only,
+            analyzer,
+            analyze,
+            modules,
+            jobs,
+            format,
+        }) => {
+            let opts = BatchOpts {
+                convert: output.is_some(),
+                output_dir: output,
+                diagnostics: diagnostics || diagnostics_only || !analyzer.is_empty(),
+                diagnostics_only,
+                analyzer_filter: analyzer,
+                analyze: analyze || !modules.is_empty(),
+                module_filter: modules,
+            };
+
+            // Validate filters upfront
+            if !opts.analyzer_filter.is_empty() {
+                if let Err(e) =
+                    flight_review::diagnostics::create_analyzers_filtered(&opts.analyzer_filter)
+                {
+                    eprintln!("error: {e}");
+                    std::process::exit(1);
+                }
+            }
+            if !opts.module_filter.is_empty() {
+                if let Err(e) =
+                    flight_review::signal_processing::create_analyses_filtered(&opts.module_filter)
+                {
+                    eprintln!("error: {e}");
+                    std::process::exit(1);
+                }
+            }
+
+            // Default: if nothing specified, just convert
+            let opts = if !opts.convert && !opts.diagnostics && !opts.analyze {
+                eprintln!("hint: use -o <DIR> to convert, --diagnostics to scan, --analyze for signal processing");
+                eprintln!();
+                BatchOpts {
+                    diagnostics: true,
+                    diagnostics_only: true,
+                    ..opts
+                }
+            } else {
+                opts
+            };
+
+            run_batch(&path, &opts, jobs, &format);
             return;
         }
         None => {}
     }
 
+    // --- Single-file mode (no subcommand) ---
+
     let input = match cli.input {
         Some(ref i) => i.as_str(),
         None => {
             eprintln!("error: missing input file");
-            eprintln!("Usage: ulog-convert <INPUT> [OPTIONS]");
-            eprintln!("       ulog-convert scan <DIR> [OPTIONS]");
+            eprintln!();
+            eprintln!("Usage:");
+            eprintln!("  ulog-convert <FILE> [OPTIONS]           Convert a single file");
+            eprintln!("  ulog-convert batch <DIR> [OPTIONS]      Batch process a directory");
+            eprintln!("  ulog-convert analyze <FILE> [OPTIONS]   Run signal processing");
+            eprintln!("  ulog-convert list                       List available modules");
             std::process::exit(1);
         }
     };
@@ -208,7 +276,7 @@ fn main() {
         let result = match flight_review::pid_analysis::pid_analysis(input) {
             Ok(r) => r,
             Err(e) => {
-                eprintln!("error: {}", e);
+                eprintln!("error: {e}");
                 std::process::exit(1);
             }
         };
@@ -216,7 +284,7 @@ fn main() {
             OutputFormat::Pretty => serde_json::to_string_pretty(&result).unwrap(),
             OutputFormat::Compact => serde_json::to_string(&result).unwrap(),
         };
-        println!("{}", json);
+        println!("{json}");
         if !cli.metadata_only {
             return;
         }
@@ -226,7 +294,7 @@ fn main() {
         let mut metadata = match flight_review::metadata::extract_metadata(input) {
             Ok(m) => m,
             Err(e) => {
-                eprintln!("error: {}", e);
+                eprintln!("error: {e}");
                 std::process::exit(1);
             }
         };
@@ -245,7 +313,7 @@ fn main() {
                 eprintln!("Metadata written to {}", meta_path.display());
             }
             None => {
-                println!("{}", json);
+                println!("{json}");
             }
         }
         return;
@@ -258,7 +326,7 @@ fn main() {
             .unwrap_or_default()
             .to_string_lossy()
             .to_string();
-        format!("{}_parquet", stem)
+        format!("{stem}_parquet")
     });
 
     let output_path = Path::new(&output_dir);
@@ -267,7 +335,7 @@ fn main() {
     let result = match flight_review::converter::convert_ulog(input, output_path) {
         Ok(r) => r,
         Err(e) => {
-            eprintln!("error: {}", e);
+            eprintln!("error: {e}");
             std::process::exit(1);
         }
     };
@@ -280,8 +348,11 @@ fn main() {
         .filter_map(|p| std::fs::metadata(p).ok().map(|m| m.len()))
         .sum();
 
-    eprintln!("Converted: {}", input);
-    eprintln!("Output:    {} ({} files)", output_dir, result.parquet_files.len());
+    eprintln!("Converted: {input}");
+    eprintln!(
+        "Output:    {output_dir} ({} files)",
+        result.parquet_files.len()
+    );
     eprintln!(
         "Size:      {:.1} MB -> {:.1} MB ({:.0}% of original)",
         input_size as f64 / 1024.0 / 1024.0,
@@ -294,7 +365,6 @@ fn main() {
         input_size as f64 / 1024.0 / 1024.0 / elapsed.as_secs_f64()
     );
 
-    // Write metadata JSON
     let meta_path = output_path.join("metadata.json");
     let meta_json = serialize_metadata(&result.metadata, &cli.output_format);
     std::fs::write(&meta_path, &meta_json).unwrap();
@@ -314,11 +384,29 @@ fn main() {
     );
 }
 
-/// Scan result for a single ULog file.
+// ---------------------------------------------------------------------------
+// Batch processing
+// ---------------------------------------------------------------------------
+
+struct BatchOpts {
+    convert: bool,
+    output_dir: Option<String>,
+    diagnostics: bool,
+    diagnostics_only: bool,
+    analyzer_filter: Vec<String>,
+    analyze: bool,
+    module_filter: Vec<String>,
+}
+
 #[derive(serde::Serialize)]
-struct ScanResult {
+struct BatchResult {
     file: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    converted: Option<bool>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     diagnostics: Vec<flight_review::diagnostics::Diagnostic>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    analyses: Option<std::collections::HashMap<String, serde_json::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     vehicle: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -329,8 +417,7 @@ struct ScanResult {
     error: Option<String>,
 }
 
-fn run_scan(dir: &str, diagnostics_only: bool, analyzer_filter: &[String], jobs: Option<usize>, format: &ScanFormat) {
-    // Collect all .ulg files
+fn run_batch(dir: &str, opts: &BatchOpts, jobs: Option<usize>, format: &BatchFormat) {
     let files: Vec<String> = walkdir::WalkDir::new(dir)
         .into_iter()
         .filter_map(|e| e.ok())
@@ -343,12 +430,26 @@ fn run_scan(dir: &str, diagnostics_only: bool, analyzer_filter: &[String], jobs:
         .collect();
 
     if files.is_empty() {
-        eprintln!("No .ulg files found in {}", dir);
+        eprintln!("No .ulg files found in {dir}");
         std::process::exit(1);
     }
 
     let total = files.len();
-    eprintln!("Scanning {} ULog files...\n", total);
+    let mut actions = Vec::new();
+    if opts.convert {
+        actions.push("convert");
+    }
+    if opts.diagnostics {
+        actions.push("diagnostics");
+    }
+    if opts.analyze {
+        actions.push("analyze");
+    }
+    eprintln!(
+        "Processing {} ULog files [{}]...\n",
+        total,
+        actions.join(", ")
+    );
 
     if let Some(j) = jobs {
         rayon::ThreadPoolBuilder::new()
@@ -359,12 +460,13 @@ fn run_scan(dir: &str, diagnostics_only: bool, analyzer_filter: &[String], jobs:
 
     let processed = AtomicUsize::new(0);
     let with_diags = AtomicUsize::new(0);
+    let converted = AtomicUsize::new(0);
     let errors = AtomicUsize::new(0);
 
-    let results: Vec<ScanResult> = files
+    let results: Vec<BatchResult> = files
         .par_iter()
         .filter_map(|file| {
-            let result = scan_one_file(file, analyzer_filter);
+            let result = process_one_file(file, opts);
             let n = processed.fetch_add(1, Ordering::Relaxed) + 1;
 
             if result.error.is_some() {
@@ -373,13 +475,19 @@ fn run_scan(dir: &str, diagnostics_only: bool, analyzer_filter: &[String], jobs:
             if !result.diagnostics.is_empty() {
                 with_diags.fetch_add(1, Ordering::Relaxed);
             }
+            if result.converted == Some(true) {
+                converted.fetch_add(1, Ordering::Relaxed);
+            }
 
-            // Progress on stderr every 100 files
             if n.is_multiple_of(100) || n == total {
                 eprint!("\r  [{n}/{total}] processed");
             }
 
-            if diagnostics_only && result.diagnostics.is_empty() && result.error.is_none() {
+            // Filter out empty results if diagnostics-only
+            if opts.diagnostics_only
+                && result.diagnostics.is_empty()
+                && result.error.is_none()
+            {
                 return None;
             }
 
@@ -389,15 +497,15 @@ fn run_scan(dir: &str, diagnostics_only: bool, analyzer_filter: &[String], jobs:
 
     eprintln!();
 
-    // Output results
+    // Output
     match format {
-        ScanFormat::Table => print_table(&results),
-        ScanFormat::Json => {
+        BatchFormat::Table => print_table(&results, opts),
+        BatchFormat::Json => {
             for r in &results {
                 println!("{}", serde_json::to_string(r).unwrap());
             }
         }
-        ScanFormat::JsonPretty => {
+        BatchFormat::JsonPretty => {
             for r in &results {
                 println!("{}", serde_json::to_string_pretty(r).unwrap());
             }
@@ -406,105 +514,28 @@ fn run_scan(dir: &str, diagnostics_only: bool, analyzer_filter: &[String], jobs:
 
     // Summary
     let diag_count = with_diags.load(Ordering::Relaxed);
+    let conv_count = converted.load(Ordering::Relaxed);
     let err_count = errors.load(Ordering::Relaxed);
-    eprintln!("\n{total} files scanned, {diag_count} with diagnostics, {err_count} errors");
+    let mut parts = vec![format!("{total} files")];
+    if opts.convert {
+        parts.push(format!("{conv_count} converted"));
+    }
+    if opts.diagnostics {
+        parts.push(format!("{diag_count} with diagnostics"));
+    }
+    parts.push(format!("{err_count} errors"));
+    eprintln!("\n{}", parts.join(", "));
 }
 
-fn print_table(results: &[ScanResult]) {
-    if results.is_empty() {
-        println!("No results.");
-        return;
-    }
-
-    println!(
-        "{:<44} {:<16} {:<10} DIAGNOSTICS",
-        "FILE", "VEHICLE", "HARDWARE"
-    );
-    println!("{}", "-".repeat(110));
-
-    for r in results {
-        if let Some(ref err) = r.error {
-            println!(
-                "{:<44} {:<16} {:<10} ERROR: {}",
-                truncate_path(&r.file, 44),
-                r.vehicle.as_deref().unwrap_or("-"),
-                r.hardware.as_deref().unwrap_or("-"),
-                err,
-            );
-            continue;
-        }
-
-        if r.diagnostics.is_empty() {
-            println!(
-                "{:<44} {:<16} {:<10} -",
-                truncate_path(&r.file, 44),
-                r.vehicle.as_deref().unwrap_or("-"),
-                r.hardware.as_deref().unwrap_or("-"),
-            );
-            continue;
-        }
-
-        // Group diagnostics by id with count
-        let mut counts: Vec<(String, usize)> = Vec::new();
-        for d in &r.diagnostics {
-            if let Some(entry) = counts.iter_mut().find(|(id, _)| id == &d.id) {
-                entry.1 += 1;
-            } else {
-                counts.push((d.id.clone(), 1));
-            }
-        }
-
-        let diag_str: Vec<String> = counts
-            .iter()
-            .map(|(id, n)| {
-                if *n > 1 {
-                    format!("{id}({n})")
-                } else {
-                    id.clone()
-                }
-            })
-            .collect();
-
-        // Color severity: find worst
-        let worst = if r.diagnostics.iter().any(|d| {
-            matches!(d.severity, flight_review::diagnostics::Severity::Critical)
-        }) {
-            "!"
-        } else {
-            " "
-        };
-
-        println!(
-            "{:<44} {:<16} {:<10} {worst} {}",
-            truncate_path(&r.file, 44),
-            r.vehicle.as_deref().unwrap_or("-"),
-            r.hardware.as_deref().unwrap_or("-"),
-            diag_str.join(", "),
-        );
-    }
-}
-
-fn truncate_path(path: &str, max_len: usize) -> String {
-    if path.len() <= max_len {
-        return path.to_string();
-    }
-    // Show .../<last two components>
-    let parts: Vec<&str> = path.rsplit('/').take(2).collect();
-    let short = format!(".../{}", parts.into_iter().rev().collect::<Vec<_>>().join("/"));
-    if short.len() <= max_len {
-        short
-    } else {
-        format!("...{}", &path[path.len() - (max_len - 3)..])
-    }
-}
-
-fn scan_one_file(path: &str, analyzer_filter: &[String]) -> ScanResult {
+fn process_one_file(path: &str, opts: &BatchOpts) -> BatchResult {
     let metadata = match flight_review::metadata::extract_metadata(path) {
         Ok(m) => m,
         Err(e) => {
-            return ScanResult {
+            return BatchResult {
                 file: path.to_string(),
+                converted: None,
                 diagnostics: vec![],
+                analyses: None,
                 vehicle: None,
                 hardware: None,
                 duration_s: None,
@@ -513,36 +544,178 @@ fn scan_one_file(path: &str, analyzer_filter: &[String]) -> ScanResult {
         }
     };
 
-    let analysis = match flight_review::analysis::analyze(path, &metadata) {
-        Ok(a) => a,
-        Err(e) => {
-            return ScanResult {
-                file: path.to_string(),
-                diagnostics: vec![],
-                vehicle: metadata.sys_name.clone(),
-                hardware: metadata.ver_hw.clone(),
-                duration_s: metadata.flight_duration_s,
-                error: Some(e.to_string()),
-            };
+    let vehicle = metadata.sys_name.clone();
+    let hardware = metadata.ver_hw.clone();
+    let duration_s = metadata.flight_duration_s;
+
+    // Conversion
+    let mut did_convert = None;
+    if opts.convert {
+        if let Some(ref output_dir) = opts.output_dir {
+            let stem = Path::new(path)
+                .file_stem()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            let file_output = Path::new(output_dir).join(&stem);
+            match flight_review::converter::convert_ulog(path, &file_output) {
+                Ok(result) => {
+                    let meta_json = serde_json::to_string_pretty(&result.metadata).unwrap();
+                    let _ = std::fs::write(file_output.join("metadata.json"), &meta_json);
+                    did_convert = Some(true);
+                }
+                Err(e) => {
+                    return BatchResult {
+                        file: path.to_string(),
+                        converted: Some(false),
+                        diagnostics: vec![],
+                        analyses: None,
+                        vehicle,
+                        hardware,
+                        duration_s,
+                        error: Some(e.to_string()),
+                    };
+                }
+            }
         }
-    };
+    }
 
-    let diagnostics = if analyzer_filter.is_empty() {
-        analysis.diagnostics
+    // Diagnostics
+    let diagnostics = if opts.diagnostics {
+        match flight_review::analysis::analyze(path, &metadata) {
+            Ok(analysis) => {
+                if opts.analyzer_filter.is_empty() {
+                    analysis.diagnostics
+                } else {
+                    analysis
+                        .diagnostics
+                        .into_iter()
+                        .filter(|d| opts.analyzer_filter.iter().any(|id| id == &d.id))
+                        .collect()
+                }
+            }
+            Err(_) => vec![],
+        }
     } else {
-        analysis
-            .diagnostics
-            .into_iter()
-            .filter(|d| analyzer_filter.iter().any(|id| id == &d.id))
-            .collect()
+        vec![]
     };
 
-    ScanResult {
+    // Signal processing
+    let analyses = if opts.analyze {
+        let modules = if opts.module_filter.is_empty() {
+            flight_review::signal_processing::create_analyses()
+        } else {
+            flight_review::signal_processing::create_analyses_filtered(&opts.module_filter)
+                .unwrap_or_default()
+        };
+        match flight_review::signal_processing::run_analyses(path, &modules) {
+            Ok(r) if !r.is_empty() => Some(r),
+            _ => None,
+        }
+    } else {
+        None
+    };
+
+    BatchResult {
         file: path.to_string(),
+        converted: did_convert,
         diagnostics,
-        vehicle: metadata.sys_name.clone(),
-        hardware: metadata.ver_hw.clone(),
-        duration_s: metadata.flight_duration_s,
+        analyses,
+        vehicle,
+        hardware,
+        duration_s,
         error: None,
+    }
+}
+
+fn print_table(results: &[BatchResult], opts: &BatchOpts) {
+    if results.is_empty() {
+        println!("No results.");
+        return;
+    }
+
+    // Dynamic header based on what was requested
+    let mut header = format!("{:<44} {:<16} {:<10}", "FILE", "VEHICLE", "HARDWARE");
+    if opts.convert {
+        header.push_str(" CONV");
+    }
+    if opts.diagnostics {
+        header.push_str(" DIAGNOSTICS");
+    }
+    println!("{header}");
+    println!("{}", "-".repeat(header.len().max(110)));
+
+    for r in results {
+        let mut line = format!(
+            "{:<44} {:<16} {:<10}",
+            truncate_path(&r.file, 44),
+            r.vehicle.as_deref().unwrap_or("-"),
+            r.hardware.as_deref().unwrap_or("-"),
+        );
+
+        if let Some(ref err) = r.error {
+            line.push_str(&format!(" ERROR: {err}"));
+            println!("{line}");
+            continue;
+        }
+
+        if opts.convert {
+            match r.converted {
+                Some(true) => line.push_str("  ok "),
+                Some(false) => line.push_str(" FAIL"),
+                None => line.push_str("  -  "),
+            }
+        }
+
+        if opts.diagnostics {
+            if r.diagnostics.is_empty() {
+                line.push_str(" -");
+            } else {
+                let mut counts: Vec<(String, usize)> = Vec::new();
+                for d in &r.diagnostics {
+                    if let Some(entry) = counts.iter_mut().find(|(id, _)| id == &d.id) {
+                        entry.1 += 1;
+                    } else {
+                        counts.push((d.id.clone(), 1));
+                    }
+                }
+                let diag_str: Vec<String> = counts
+                    .iter()
+                    .map(|(id, n)| {
+                        if *n > 1 {
+                            format!("{id}({n})")
+                        } else {
+                            id.clone()
+                        }
+                    })
+                    .collect();
+                let worst = if r.diagnostics.iter().any(|d| {
+                    matches!(d.severity, flight_review::diagnostics::Severity::Critical)
+                }) {
+                    "!"
+                } else {
+                    " "
+                };
+                line.push_str(&format!(" {worst} {}", diag_str.join(", ")));
+            }
+        }
+
+        println!("{line}");
+    }
+}
+
+fn truncate_path(path: &str, max_len: usize) -> String {
+    if path.len() <= max_len {
+        return path.to_string();
+    }
+    let parts: Vec<&str> = path.rsplit('/').take(2).collect();
+    let short = format!(
+        ".../{}",
+        parts.into_iter().rev().collect::<Vec<_>>().join("/")
+    );
+    if short.len() <= max_len {
+        short
+    } else {
+        format!("...{}", &path[path.len() - (max_len - 3)..])
     }
 }

--- a/crates/converter/src/bin/ulog_convert.rs
+++ b/crates/converter/src/bin/ulog_convert.rs
@@ -361,6 +361,8 @@ struct BatchResult {
     file: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     converted: Option<bool>,
+    #[serde(skip)]
+    output_dir: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     diagnostics: Vec<flight_review::diagnostics::Diagnostic>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -373,6 +375,27 @@ struct BatchResult {
     duration_s: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+}
+
+/// Top-level index for batch conversions.
+#[derive(serde::Serialize)]
+struct BatchIndex {
+    version: u32,
+    total: usize,
+    logs: Vec<BatchIndexEntry>,
+}
+
+#[derive(serde::Serialize)]
+struct BatchIndexEntry {
+    path: String,
+    manifest: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    vehicle: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hardware: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    duration_s: Option<f64>,
+    diagnostic_count: usize,
 }
 
 fn run_batch(dir: &str, opts: &BatchOpts, jobs: Option<usize>, format: &BatchFormat) {
@@ -470,6 +493,37 @@ fn run_batch(dir: &str, opts: &BatchOpts, jobs: Option<usize>, format: &BatchFor
         }
     }
 
+    // Write batch-level index.json if converting
+    if let Some(ref output_dir) = opts.output_dir {
+        let entries: Vec<BatchIndexEntry> = results
+            .iter()
+            .filter(|r| r.converted == Some(true))
+            .filter_map(|r| {
+                let dir_name = r.output_dir.as_ref()?;
+                Some(BatchIndexEntry {
+                    path: dir_name.clone(),
+                    manifest: format!("{dir_name}/manifest.json"),
+                    vehicle: r.vehicle.clone(),
+                    hardware: r.hardware.clone(),
+                    duration_s: r.duration_s,
+                    diagnostic_count: r.diagnostics.len(),
+                })
+            })
+            .collect();
+
+        let index = BatchIndex {
+            version: 1,
+            total: entries.len(),
+            logs: entries,
+        };
+
+        let index_path = Path::new(output_dir).join("index.json");
+        if let Ok(json) = serde_json::to_string_pretty(&index) {
+            let _ = std::fs::write(&index_path, json);
+            eprintln!("Index:  {}", index_path.display());
+        }
+    }
+
     // Summary
     let diag_count = with_diags.load(Ordering::Relaxed);
     let conv_count = converted.load(Ordering::Relaxed);
@@ -492,6 +546,7 @@ fn process_one_file(path: &str, opts: &BatchOpts) -> BatchResult {
             return BatchResult {
                 file: path.to_string(),
                 converted: None,
+                output_dir: None,
                 diagnostics: vec![],
                 analyses: None,
                 vehicle: None,
@@ -508,6 +563,7 @@ fn process_one_file(path: &str, opts: &BatchOpts) -> BatchResult {
 
     // Conversion
     let mut did_convert = None;
+    let mut convert_output_dir = None;
     if opts.convert {
         if let Some(ref output_dir) = opts.output_dir {
             let stem = Path::new(path)
@@ -521,11 +577,13 @@ fn process_one_file(path: &str, opts: &BatchOpts) -> BatchResult {
                     let meta_json = serde_json::to_string_pretty(&result.metadata).unwrap();
                     let _ = std::fs::write(file_output.join("metadata.json"), &meta_json);
                     did_convert = Some(true);
+                    convert_output_dir = Some(stem);
                 }
                 Err(e) => {
                     return BatchResult {
                         file: path.to_string(),
                         converted: Some(false),
+                        output_dir: None,
                         diagnostics: vec![],
                         analyses: None,
                         vehicle,
@@ -577,6 +635,7 @@ fn process_one_file(path: &str, opts: &BatchOpts) -> BatchResult {
     BatchResult {
         file: path.to_string(),
         converted: did_convert,
+        output_dir: convert_output_dir,
         diagnostics,
         analyses,
         vehicle,

--- a/crates/converter/src/bin/ulog_convert.rs
+++ b/crates/converter/src/bin/ulog_convert.rs
@@ -48,13 +48,14 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
-    /// List available diagnostic analyzers and signal processing modules
-    List,
-
     /// Batch process a directory of ULog files
     ///
     /// Convert, diagnose, and analyze ULog files in parallel.
-    /// By default converts to Parquet + metadata.json.
+    ///
+    /// Diagnostics: motor_failure, gps_interference, battery_brownout,
+    /// ekf_failure, rc_loss
+    ///
+    /// Signal processing: pid_step_response
     Batch {
         /// Directory containing .ulg files (searched recursively)
         path: String,
@@ -93,17 +94,15 @@ enum Command {
     },
 
     /// Run signal processing analyses on a single ULog file
+    ///
+    /// Modules: pid_step_response
     Analyze {
-        /// Input ULog file (required unless --list)
-        file: Option<String>,
+        /// Input ULog file
+        file: String,
 
         /// Run only specific module(s), comma-separated
         #[arg(long, short, value_delimiter = ',')]
         modules: Vec<String>,
-
-        /// List available analysis modules
-        #[arg(long)]
-        list: bool,
 
         /// Output format
         #[arg(long, value_enum, default_value_t = OutputFormat::Pretty)]
@@ -125,52 +124,11 @@ fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-        Some(Command::List) => {
-            println!("Diagnostic analyzers:");
-            println!();
-            let analyzers = flight_review::diagnostics::create_analyzers();
-            for a in &analyzers {
-                println!("  {:<24} {}", a.id(), a.description());
-            }
-
-            println!();
-            println!("Signal processing modules:");
-            println!();
-            let analyses = flight_review::signal_processing::create_analyses();
-            for a in &analyses {
-                println!("  {:<24} {}", a.id(), a.description());
-            }
-            return;
-        }
         Some(Command::Analyze {
             file,
             modules,
-            list,
             output_format,
         }) => {
-            if list {
-                let analyses = flight_review::signal_processing::create_analyses();
-                for a in &analyses {
-                    println!("{:<24} {}", a.id(), a.description());
-                    let signals = a.required_signals();
-                    let mut topics: Vec<&str> =
-                        signals.iter().map(|s| s.topic.as_str()).collect();
-                    topics.sort();
-                    topics.dedup();
-                    println!("{:<24} topics: {}", "", topics.join(", "));
-                    println!();
-                }
-                return;
-            }
-
-            let file = match file {
-                Some(f) => f,
-                None => {
-                    eprintln!("error: <FILE> is required when not using --list");
-                    std::process::exit(1);
-                }
-            };
-
             let analyses = if modules.is_empty() {
                 flight_review::signal_processing::create_analyses()
             } else {

--- a/crates/converter/src/bin/ulog_convert.rs
+++ b/crates/converter/src/bin/ulog_convert.rs
@@ -72,6 +72,24 @@ enum Command {
         #[arg(long, value_enum, default_value_t = ScanFormat::Table)]
         output_format: ScanFormat,
     },
+
+    /// Run signal processing analyses on a ULog file
+    Analyze {
+        /// Input ULog file (required unless --list)
+        file: Option<String>,
+
+        /// Run only specific module(s), comma-separated
+        #[arg(long, short, value_delimiter = ',')]
+        modules: Vec<String>,
+
+        /// List available analysis modules
+        #[arg(long)]
+        list: bool,
+
+        /// Output format
+        #[arg(long, value_enum, default_value_t = OutputFormat::Pretty)]
+        output_format: OutputFormat,
+    },
 }
 
 fn serialize_metadata(
@@ -95,6 +113,65 @@ fn main() {
                 println!("{:<20} topics: {}", "", a.required_topics().join(", "));
                 println!();
             }
+            return;
+        }
+        Some(Command::Analyze {
+            file,
+            modules,
+            list,
+            output_format,
+        }) => {
+            if list {
+                let analyses = flight_review::signal_processing::create_analyses();
+                for a in &analyses {
+                    println!("{:<24} {}", a.id(), a.description());
+                    let signals = a.required_signals();
+                    let topics: Vec<String> = {
+                        let mut t: Vec<&str> = signals.iter().map(|s| s.topic.as_str()).collect();
+                        t.sort();
+                        t.dedup();
+                        t.into_iter().map(String::from).collect()
+                    };
+                    println!("{:<24} topics: {}", "", topics.join(", "));
+                    println!();
+                }
+                return;
+            }
+
+            let file = match file {
+                Some(f) => f,
+                None => {
+                    eprintln!("error: <FILE> is required when not using --list");
+                    std::process::exit(1);
+                }
+            };
+
+            let analyses = if modules.is_empty() {
+                flight_review::signal_processing::create_analyses()
+            } else {
+                match flight_review::signal_processing::create_analyses_filtered(&modules) {
+                    Ok(a) => a,
+                    Err(e) => {
+                        eprintln!("error: {}", e);
+                        std::process::exit(1);
+                    }
+                }
+            };
+
+            let results =
+                match flight_review::signal_processing::run_analyses(&file, &analyses) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        eprintln!("error: {}", e);
+                        std::process::exit(1);
+                    }
+                };
+
+            let json = match output_format {
+                OutputFormat::Pretty => serde_json::to_string_pretty(&results).unwrap(),
+                OutputFormat::Compact => serde_json::to_string(&results).unwrap(),
+            };
+            println!("{}", json);
             return;
         }
         Some(Command::Scan {

--- a/crates/converter/src/converter.rs
+++ b/crates/converter/src/converter.rs
@@ -17,6 +17,8 @@ use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;
 use px4_ulog::full_parser::SomeVec;
 
+use serde::{Deserialize, Serialize};
+
 use crate::metadata::FlightMetadata;
 
 #[derive(Debug, thiserror::Error)]
@@ -37,6 +39,64 @@ pub struct ConvertResult {
     pub parquet_files: Vec<PathBuf>,
     /// Extracted flight metadata.
     pub metadata: FlightMetadata,
+}
+
+/// Conversion manifest — describes what was produced and where to find it.
+///
+/// Written as `manifest.json` alongside the Parquet files. Provides a
+/// self-describing map of the conversion output for downstream consumers
+/// (data scientists, ML pipelines, etc.).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Manifest {
+    /// Manifest format version.
+    pub version: u32,
+    /// Original source file name.
+    pub source: String,
+    /// Vehicle name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vehicle: Option<String>,
+    /// Hardware identifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hardware: Option<String>,
+    /// Flight duration in seconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_s: Option<f64>,
+    /// File map: topic name → relative Parquet file path.
+    pub topics: HashMap<String, String>,
+    /// Diagnostic results (empty if no anomalies detected).
+    pub diagnostics: Vec<crate::diagnostics::Diagnostic>,
+}
+
+impl Manifest {
+    /// Build a manifest from a conversion result and the original filename.
+    pub fn from_result(result: &ConvertResult, source_filename: &str) -> Self {
+        let topics: HashMap<String, String> = result
+            .parquet_files
+            .iter()
+            .filter_map(|p| {
+                let filename = p.file_name()?.to_str()?.to_string();
+                let topic = filename.strip_suffix(".parquet")?.to_string();
+                Some((topic, filename))
+            })
+            .collect();
+
+        let diagnostics = result
+            .metadata
+            .analysis
+            .as_ref()
+            .map(|a| a.diagnostics.clone())
+            .unwrap_or_default();
+
+        Self {
+            version: 1,
+            source: source_filename.to_string(),
+            vehicle: result.metadata.sys_name.clone(),
+            hardware: result.metadata.ver_hw.clone(),
+            duration_s: result.metadata.flight_duration_s,
+            topics,
+            diagnostics,
+        }
+    }
 }
 
 /// Convert a ULog file to per-topic Parquet files in the given output directory.
@@ -70,10 +130,22 @@ pub fn convert_ulog(input_path: &str, output_dir: &Path) -> Result<ConvertResult
         }
     }
 
-    Ok(ConvertResult {
+    let result = ConvertResult {
         parquet_files,
         metadata,
-    })
+    };
+
+    // Write manifest
+    let source_name = Path::new(input_path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown.ulg");
+    let manifest = Manifest::from_result(&result, source_name);
+    let manifest_json = serde_json::to_string_pretty(&manifest)
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
+    std::fs::write(output_dir.join("manifest.json"), manifest_json)?;
+
+    Ok(result)
 }
 
 /// Write a single topic's data as a Parquet file.

--- a/crates/converter/src/lib.rs
+++ b/crates/converter/src/lib.rs
@@ -3,3 +3,4 @@ pub mod converter;
 pub mod diagnostics;
 pub mod metadata;
 pub mod pid_analysis;
+pub mod signal_processing;

--- a/crates/converter/src/pid_analysis.rs
+++ b/crates/converter/src/pid_analysis.rs
@@ -1,531 +1,58 @@
-//! PID step response analysis using Wiener deconvolution.
+//! PID step response analysis — backward-compatible entry point.
 //!
-//! Extracts the step response of the PID controller for each axis (roll, pitch, yaw)
-//! by deconvolving the rate setpoint (input) from the actual angular rate (output).
-//! This answers: "when the controller commands a rate change, how does the vehicle
-//! actually respond?"
+//! This module delegates to [`crate::signal_processing::pid_step_response`].
+//! Use [`pid_analysis()`] for the legacy API, or the signal processing
+//! framework directly via [`crate::signal_processing::run_analyses()`].
 
-use px4_ulog::stream_parser::file_reader::{
-    read_file_with_simple_callback, Message, SimpleCallbackResult,
+// Re-export types for backward compatibility
+pub use crate::signal_processing::pid_step_response::{
+    PidAnalysisResult, PidStepResponse, StepResponseHistogram,
 };
-use rustfft::num_complex::Complex;
-use rustfft::FftPlanner;
-use serde::{Deserialize, Serialize};
-use std::f64::consts::PI;
-
-/// A time series of (time_seconds, value) pairs.
-type TimeSeries = Vec<(f64, f64)>;
-
-// ---------------------------------------------------------------------------
-// Public types
-// ---------------------------------------------------------------------------
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PidStepResponse {
-    pub axis: String,
-    pub sample_rate_hz: f64,
-    pub window_count: usize,
-    /// Time points for the step response (0 to ~0.5s)
-    pub time_s: Vec<f64>,
-    /// Mean step response values (normalized, should approach 1.0)
-    pub mean_response: Vec<f64>,
-    /// 2D histogram: time_bins x amplitude_bins -> count
-    pub histogram: StepResponseHistogram,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StepResponseHistogram {
-    pub time_bins: Vec<f64>,
-    pub amplitude_bins: Vec<f64>,
-    /// Row-major: counts[time_idx * amplitude_bins.len() + amp_idx]
-    pub counts: Vec<u32>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PidAnalysisResult {
-    pub axes: Vec<PidStepResponse>,
-}
-
-// ---------------------------------------------------------------------------
-// Configuration constants
-// ---------------------------------------------------------------------------
-
-const WINDOW_DURATION_S: f64 = 1.0;
-const STEP_DURATION_S: f64 = 0.5;
-const RESPONSE_DURATION_S: f64 = 0.5;
-const MIN_SAMPLE_RATE_HZ: f64 = 50.0;
-const MIN_WINDOWS: usize = 3;
-const NOISE_FLOOR_FACTOR: f64 = 1e-3;
-
-const HIST_TIME_BINS: usize = 100;
-const HIST_AMP_BINS: usize = 100;
-const HIST_AMP_MIN: f64 = -0.5;
-const HIST_AMP_MAX: f64 = 2.0;
-
-// ---------------------------------------------------------------------------
-// Entry point
-// ---------------------------------------------------------------------------
 
 /// Run PID step response analysis on a ULog file.
 ///
-/// Returns results for each axis that has sufficient data. Axes with missing
-/// topics, too few windows, or a sample rate below 50 Hz are silently skipped.
+/// This is a convenience wrapper around the signal processing framework.
+/// Returns results for each axis that has sufficient data.
 pub fn pid_analysis(path: &str) -> Result<PidAnalysisResult, std::io::Error> {
-    let mut result = PidAnalysisResult { axes: Vec::new() };
-    for axis in &["roll", "pitch", "yaw"] {
-        if let Some(response) = analyze_axis(path, axis)? {
-            result.axes.push(response);
-        }
-    }
-    Ok(result)
-}
-
-// ---------------------------------------------------------------------------
-// Per-axis analysis
-// ---------------------------------------------------------------------------
-
-fn analyze_axis(path: &str, axis: &str) -> Result<Option<PidStepResponse>, std::io::Error> {
-    // 1. Extract raw signals
-    let (setpoint_raw, gyro_raw) = extract_signals(path, axis)?;
-
-    if setpoint_raw.len() < 2 || gyro_raw.len() < 2 {
-        return Ok(None);
-    }
-
-    // 2. Compute median sample rate from the setpoint signal
-    let sample_rate = median_sample_rate(&setpoint_raw);
-    if sample_rate < MIN_SAMPLE_RATE_HZ {
-        return Ok(None);
-    }
-
-    // 3. Determine the common time range
-    let t_start = setpoint_raw[0].0.max(gyro_raw[0].0);
-    let t_end = setpoint_raw.last().unwrap().0.min(gyro_raw.last().unwrap().0);
-    if t_end - t_start < WINDOW_DURATION_S {
-        return Ok(None);
-    }
-
-    // 4. Resample both signals to uniform grid
-    let setpoint = resample_uniform(&setpoint_raw, sample_rate, t_start, t_end);
-    let gyro = resample_uniform(&gyro_raw, sample_rate, t_start, t_end);
-
-    let n = setpoint.len().min(gyro.len());
-    if n < 2 {
-        return Ok(None);
-    }
-    let setpoint = &setpoint[..n];
-    let gyro = &gyro[..n];
-
-    // 5. Windowed Wiener deconvolution
-    let window_samples = (WINDOW_DURATION_S * sample_rate).round() as usize;
-    let step_samples = (STEP_DURATION_S * sample_rate).round() as usize;
-    let response_samples = (RESPONSE_DURATION_S * sample_rate).round() as usize;
-
-    if window_samples < 4 || step_samples == 0 || response_samples == 0 {
-        return Ok(None);
-    }
-
-    let hann = hanning_window(window_samples);
-
-    let mut all_step_responses: Vec<Vec<f64>> = Vec::new();
-
-    let mut offset = 0;
-    while offset + window_samples <= n {
-        let sp_win = &setpoint[offset..offset + window_samples];
-        let gy_win = &gyro[offset..offset + window_samples];
-
-        if let Some(step) =
-            wiener_step_response(sp_win, gy_win, &hann, window_samples, response_samples)
-        {
-            all_step_responses.push(step);
-        }
-
-        offset += step_samples;
-    }
-
-    if all_step_responses.len() < MIN_WINDOWS {
-        return Ok(None);
-    }
-
-    // 6. Compute mean step response
-    let resp_len = response_samples.min(
-        all_step_responses
-            .iter()
-            .map(|r| r.len())
-            .min()
-            .unwrap_or(0),
-    );
-    if resp_len == 0 {
-        return Ok(None);
-    }
-
-    let mut mean_response = vec![0.0f64; resp_len];
-    for resp in &all_step_responses {
-        for (i, &v) in resp.iter().take(resp_len).enumerate() {
-            mean_response[i] += v;
-        }
-    }
-    let count = all_step_responses.len() as f64;
-    for v in &mut mean_response {
-        *v /= count;
-    }
-
-    // 7. Build time vector
-    let dt = 1.0 / sample_rate;
-    let time_s: Vec<f64> = (0..resp_len).map(|i| i as f64 * dt).collect();
-
-    // 8. Build 2D histogram
-    let histogram = build_histogram(&all_step_responses, resp_len, &time_s);
-
-    Ok(Some(PidStepResponse {
-        axis: axis.to_string(),
-        sample_rate_hz: sample_rate,
-        window_count: all_step_responses.len(),
-        time_s,
-        mean_response,
-        histogram,
-    }))
-}
-
-// ---------------------------------------------------------------------------
-// Signal extraction
-// ---------------------------------------------------------------------------
-
-/// Extract rate setpoint and angular velocity signals for the given axis.
-/// Returns two vectors of (time_seconds, value) pairs.
-fn extract_signals(
-    path: &str,
-    axis: &str,
-) -> Result<(TimeSeries, TimeSeries), std::io::Error> {
-    let setpoint_field = match axis {
-        "roll" => "roll",
-        "pitch" => "pitch",
-        "yaw" => "yaw",
-        _ => return Ok((Vec::new(), Vec::new())),
-    };
-
-    let gyro_field = match axis {
-        "roll" => "xyz[0]",
-        "pitch" => "xyz[1]",
-        "yaw" => "xyz[2]",
-        _ => return Ok((Vec::new(), Vec::new())),
-    };
-
-    let mut setpoint_data: Vec<(f64, f64)> = Vec::new();
-    let mut gyro_data: Vec<(f64, f64)> = Vec::new();
-
-    read_file_with_simple_callback(path, &mut |msg| {
-        if let Message::Data(data) = msg {
-                let topic = data.flattened_format.message_name.as_str();
-                let ts = data
-                    .flattened_format
-                    .timestamp_field
-                    .as_ref()
-                    .map(|tf| tf.parse_timestamp(data.data));
-
-                match topic {
-                    "vehicle_rates_setpoint" => {
-                        if let (Some(ts), Ok(parser)) =
-                            (ts, data.flattened_format.get_field_parser::<f32>(setpoint_field))
-                        {
-                            let val = parser.parse(data.data) as f64;
-                            if val.is_finite() {
-                                let t_s = ts as f64 / 1_000_000.0;
-                                setpoint_data.push((t_s, val));
-                            }
-                        }
-                    }
-                    "vehicle_angular_velocity" => {
-                        if let (Some(ts), Ok(parser)) =
-                            (ts, data.flattened_format.get_field_parser::<f32>(gyro_field))
-                        {
-                            let val = parser.parse(data.data) as f64;
-                            if val.is_finite() {
-                                let t_s = ts as f64 / 1_000_000.0;
-                                gyro_data.push((t_s, val));
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            }
-        SimpleCallbackResult::KeepReading
-    })?;
-
-    // Sort by timestamp (should already be sorted, but be safe)
-    setpoint_data.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
-    gyro_data.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
-
-    Ok((setpoint_data, gyro_data))
-}
-
-// ---------------------------------------------------------------------------
-// Resampling
-// ---------------------------------------------------------------------------
-
-/// Compute the median sample rate from a time series.
-fn median_sample_rate(data: &[(f64, f64)]) -> f64 {
-    if data.len() < 2 {
-        return 0.0;
-    }
-    let mut dts: Vec<f64> = data
-        .windows(2)
-        .map(|w| w[1].0 - w[0].0)
-        .filter(|&dt| dt > 0.0)
-        .collect();
-    if dts.is_empty() {
-        return 0.0;
-    }
-    dts.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-    let median_dt = dts[dts.len() / 2];
-    if median_dt > 0.0 {
-        1.0 / median_dt
-    } else {
-        0.0
-    }
-}
-
-/// Resample non-uniform (time, value) data to a uniform grid via linear interpolation.
-fn resample_uniform(
-    data: &[(f64, f64)],
-    sample_rate: f64,
-    t_start: f64,
-    t_end: f64,
-) -> Vec<f64> {
-    let dt = 1.0 / sample_rate;
-    let n = ((t_end - t_start) / dt).floor() as usize + 1;
-    let mut result = Vec::with_capacity(n);
-
-    let mut j = 0usize; // index into data
-    for i in 0..n {
-        let t = t_start + i as f64 * dt;
-
-        // Advance j so that data[j].0 <= t < data[j+1].0
-        while j + 1 < data.len() && data[j + 1].0 <= t {
-            j += 1;
-        }
-
-        if j + 1 >= data.len() {
-            // Past the end of data, use last value
-            result.push(data.last().unwrap().1);
-        } else if t <= data[j].0 {
-            // Before or at the first applicable point
-            result.push(data[j].1);
-        } else {
-            // Linear interpolation between data[j] and data[j+1]
-            let t0 = data[j].0;
-            let t1 = data[j + 1].0;
-            let v0 = data[j].1;
-            let v1 = data[j + 1].1;
-            let frac = (t - t0) / (t1 - t0);
-            result.push(v0 + frac * (v1 - v0));
-        }
-    }
-
-    result
-}
-
-// ---------------------------------------------------------------------------
-// DSP: Hanning window, Wiener deconvolution, step response
-// ---------------------------------------------------------------------------
-
-fn hanning_window(n: usize) -> Vec<f64> {
-    (0..n)
-        .map(|i| 0.5 * (1.0 - (2.0 * PI * i as f64 / n as f64).cos()))
-        .collect()
-}
-
-/// Perform Wiener deconvolution on a single window and return the normalized
-/// step response (first `response_len` samples).
-fn wiener_step_response(
-    input: &[f64],
-    output: &[f64],
-    hann: &[f64],
-    fft_len: usize,
-    response_len: usize,
-) -> Option<Vec<f64>> {
-    // Apply Hanning window
-    let mut x: Vec<Complex<f64>> = input
-        .iter()
-        .zip(hann.iter())
-        .map(|(&s, &w)| Complex::new(s * w, 0.0))
-        .collect();
-    let mut y: Vec<Complex<f64>> = output
-        .iter()
-        .zip(hann.iter())
-        .map(|(&s, &w)| Complex::new(s * w, 0.0))
+    let analyses = crate::signal_processing::create_analyses();
+    let pid_only: Vec<_> = analyses
+        .into_iter()
+        .filter(|a| a.id() == "pid_step_response")
         .collect();
 
-    // Pad/truncate to fft_len
-    x.resize(fft_len, Complex::new(0.0, 0.0));
-    y.resize(fft_len, Complex::new(0.0, 0.0));
+    let results = crate::signal_processing::run_analyses(path, &pid_only)
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
 
-    // FFT
-    let mut planner = FftPlanner::<f64>::new();
-    let fft = planner.plan_fft_forward(fft_len);
-    fft.process(&mut x);
-    fft.process(&mut y);
-
-    // Compute noise floor = max(|X(f)|^2) * noise_floor_factor
-    let max_power = x
-        .iter()
-        .map(|c| c.norm_sqr())
-        .fold(0.0f64, |a, b| a.max(b));
-    if max_power < 1e-30 {
-        // Input is essentially silent, skip this window
-        return None;
-    }
-    let noise_floor = max_power * NOISE_FLOOR_FACTOR;
-
-    // Wiener deconvolution: H(f) = Y(f) * conj(X(f)) / (|X(f)|^2 + noise_floor)
-    let mut h: Vec<Complex<f64>> = y
-        .iter()
-        .zip(x.iter())
-        .map(|(yi, xi)| {
-            let denom = xi.norm_sqr() + noise_floor;
-            (*yi * xi.conj()) / denom
-        })
-        .collect();
-
-    // Inverse FFT to get impulse response
-    let ifft = planner.plan_fft_inverse(fft_len);
-    ifft.process(&mut h);
-
-    // Normalize by fft_len (rustfft does not normalize)
-    let scale = 1.0 / fft_len as f64;
-
-    // Extract real part of impulse response and integrate (cumulative sum) for step response
-    let resp_len = response_len.min(fft_len);
-    let mut step = Vec::with_capacity(resp_len);
-    let mut cumsum = 0.0;
-    for item in h.iter().take(resp_len) {
-        let impulse_val = item.re * scale;
-        if impulse_val.is_finite() {
-            cumsum += impulse_val;
+    match results.get("pid_step_response") {
+        Some(value) => {
+            let result: PidAnalysisResult = serde_json::from_value(value.clone())
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            Ok(result)
         }
-        step.push(cumsum);
-    }
-
-    // Normalize so step response converges to 1.0
-    let final_val = *step.last().unwrap_or(&0.0);
-    if final_val.abs() < 1e-10 {
-        return None; // Degenerate response
-    }
-    for v in &mut step {
-        *v /= final_val;
-    }
-
-    Some(step)
-}
-
-// ---------------------------------------------------------------------------
-// Histogram
-// ---------------------------------------------------------------------------
-
-fn build_histogram(
-    all_responses: &[Vec<f64>],
-    resp_len: usize,
-    time_s: &[f64],
-) -> StepResponseHistogram {
-    let time_min = 0.0f64;
-    let time_max = RESPONSE_DURATION_S;
-    let time_bin_width = (time_max - time_min) / HIST_TIME_BINS as f64;
-    let amp_bin_width = (HIST_AMP_MAX - HIST_AMP_MIN) / HIST_AMP_BINS as f64;
-
-    let time_bins: Vec<f64> = (0..HIST_TIME_BINS)
-        .map(|i| time_min + (i as f64 + 0.5) * time_bin_width)
-        .collect();
-    let amplitude_bins: Vec<f64> = (0..HIST_AMP_BINS)
-        .map(|i| HIST_AMP_MIN + (i as f64 + 0.5) * amp_bin_width)
-        .collect();
-
-    let mut counts = vec![0u32; HIST_TIME_BINS * HIST_AMP_BINS];
-
-    for resp in all_responses {
-        for (i, &val) in resp.iter().take(resp_len).enumerate() {
-            if i >= time_s.len() {
-                break;
-            }
-            let t = time_s[i];
-            let ti = ((t - time_min) / time_bin_width).floor() as isize;
-            let ai = ((val - HIST_AMP_MIN) / amp_bin_width).floor() as isize;
-
-            if ti >= 0 && (ti as usize) < HIST_TIME_BINS && ai >= 0 && (ai as usize) < HIST_AMP_BINS
-            {
-                counts[ti as usize * HIST_AMP_BINS + ai as usize] += 1;
-            }
-        }
-    }
-
-    StepResponseHistogram {
-        time_bins,
-        amplitude_bins,
-        counts,
+        None => Ok(PidAnalysisResult { axes: Vec::new() }),
     }
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn px4_ulog_fixture(name: &str) -> String {
-        let manifest = env!("CARGO_MANIFEST_DIR");
-
-        // First: check local fixtures in the converter crate
-        let local = std::path::Path::new(manifest)
-            .parent().unwrap()  // crates/
-            .parent().unwrap()  // workspace root
-            .join("crates/converter/tests/fixtures")
-            .join(name);
-        if local.exists() {
-            return local.to_string_lossy().to_string();
-        }
-
-        // Fallback: px4-ulog-rs repo (local dev)
-        let external = std::path::Path::new(manifest)
-            .parent().unwrap()  // crates/
-            .parent().unwrap()  // workspace root
-            .parent().unwrap()  // ulog/
-            .join("px4-ulog-rs/tests/fixtures")
-            .join(name);
-        external.to_string_lossy().to_string()
+        crate::signal_processing::testing::fixture_path(name)
     }
 
     #[test]
     fn test_pid_analysis_sample() {
         let path = px4_ulog_fixture("sample.ulg");
         let result = pid_analysis(&path).unwrap();
-        // The result should be valid (possibly empty if sample.ulg lacks the topics)
-        // but should not error out.
         for axis_result in &result.axes {
-            assert!(
-                axis_result.sample_rate_hz >= MIN_SAMPLE_RATE_HZ,
-                "sample rate should be above minimum"
-            );
-            assert!(
-                axis_result.window_count >= MIN_WINDOWS,
-                "should have enough windows"
-            );
-            assert!(
-                !axis_result.time_s.is_empty(),
-                "time vector should not be empty"
-            );
-            assert_eq!(
-                axis_result.time_s.len(),
-                axis_result.mean_response.len(),
-                "time and response lengths must match"
-            );
-            // Histogram dimensions
-            assert_eq!(axis_result.histogram.time_bins.len(), HIST_TIME_BINS);
-            assert_eq!(axis_result.histogram.amplitude_bins.len(), HIST_AMP_BINS);
-            assert_eq!(
-                axis_result.histogram.counts.len(),
-                HIST_TIME_BINS * HIST_AMP_BINS
-            );
+            assert!(axis_result.sample_rate_hz >= 50.0);
+            assert!(axis_result.window_count >= 3);
+            assert!(!axis_result.time_s.is_empty());
+            assert_eq!(axis_result.time_s.len(), axis_result.mean_response.len());
+            assert_eq!(axis_result.histogram.time_bins.len(), 100);
+            assert_eq!(axis_result.histogram.amplitude_bins.len(), 100);
+            assert_eq!(axis_result.histogram.counts.len(), 100 * 100);
         }
     }
 
@@ -537,61 +64,9 @@ mod tests {
             return;
         }
         let result = pid_analysis(&path).unwrap();
-        // Should not error; may or may not have axes depending on log content
         for axis_result in &result.axes {
-            assert!(axis_result.window_count >= MIN_WINDOWS);
+            assert!(axis_result.window_count >= 3);
             assert!(!axis_result.mean_response.is_empty());
-        }
-    }
-
-    #[test]
-    fn test_resample_uniform_basic() {
-        let data = vec![(0.0, 1.0), (1.0, 3.0), (2.0, 5.0)];
-        let result = resample_uniform(&data, 2.0, 0.0, 2.0);
-        // At rate 2.0 Hz from 0 to 2: t = 0.0, 0.5, 1.0, 1.5, 2.0
-        assert_eq!(result.len(), 5);
-        assert!((result[0] - 1.0).abs() < 1e-9); // t=0
-        assert!((result[1] - 2.0).abs() < 1e-9); // t=0.5
-        assert!((result[2] - 3.0).abs() < 1e-9); // t=1.0
-        assert!((result[3] - 4.0).abs() < 1e-9); // t=1.5
-        assert!((result[4] - 5.0).abs() < 1e-9); // t=2.0
-    }
-
-    #[test]
-    fn test_hanning_window() {
-        let w = hanning_window(4);
-        assert_eq!(w.len(), 4);
-        // Hanning window for n=4:
-        // i=0: 0.5*(1 - cos(0)) = 0
-        // i=1: 0.5*(1 - cos(pi/2)) = 0.5
-        // i=2: 0.5*(1 - cos(pi)) = 1.0
-        // i=3: 0.5*(1 - cos(3pi/2)) = 0.5
-        assert!(w[0].abs() < 1e-10);
-        assert!((w[1] - 0.5).abs() < 1e-10);
-        assert!((w[2] - 1.0).abs() < 1e-10);
-        assert!((w[3] - 0.5).abs() < 1e-10);
-    }
-
-    #[test]
-    fn test_median_sample_rate() {
-        let data: Vec<(f64, f64)> = (0..100).map(|i| (i as f64 * 0.01, 0.0)).collect();
-        let rate = median_sample_rate(&data);
-        assert!((rate - 100.0).abs() < 1.0);
-    }
-
-    #[test]
-    fn test_wiener_step_response_identity() {
-        // If input == output, the step response should be roughly a step to 1.0
-        let n = 128;
-        let hann = hanning_window(n);
-        let signal: Vec<f64> = (0..n).map(|i| (i as f64 * 0.1).sin()).collect();
-        let resp = wiener_step_response(&signal, &signal, &hann, n, n / 2);
-        // When input == output, the impulse response is a delta, so the step
-        // response should jump to ~1.0 quickly.
-        if let Some(r) = resp {
-            assert!(!r.is_empty());
-            // The last value should be 1.0 (normalized)
-            assert!((r.last().unwrap() - 1.0).abs() < 1e-6);
         }
     }
 }

--- a/crates/converter/src/signal_processing/dsp.rs
+++ b/crates/converter/src/signal_processing/dsp.rs
@@ -1,0 +1,120 @@
+//! Shared DSP utilities for signal processing modules.
+//!
+//! Provides common functions for resampling, windowing, and sample rate
+//! estimation. These are used by multiple analysis modules.
+
+use std::f64::consts::PI;
+
+/// Compute the median sample rate from a non-uniform time series.
+///
+/// Returns 0.0 if the time series has fewer than 2 points or all
+/// intervals are zero.
+pub fn median_sample_rate(data: &[(f64, f64)]) -> f64 {
+    if data.len() < 2 {
+        return 0.0;
+    }
+    let mut dts: Vec<f64> = data
+        .windows(2)
+        .map(|w| w[1].0 - w[0].0)
+        .filter(|&dt| dt > 0.0)
+        .collect();
+    if dts.is_empty() {
+        return 0.0;
+    }
+    dts.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let median_dt = dts[dts.len() / 2];
+    if median_dt > 0.0 {
+        1.0 / median_dt
+    } else {
+        0.0
+    }
+}
+
+/// Resample non-uniform (time, value) data to a uniform grid via linear interpolation.
+///
+/// Creates a uniform time grid from `t_start` to `t_end` at the given
+/// `sample_rate` (Hz) and interpolates values linearly between adjacent
+/// input samples.
+pub fn resample_uniform(
+    data: &[(f64, f64)],
+    sample_rate: f64,
+    t_start: f64,
+    t_end: f64,
+) -> Vec<f64> {
+    let dt = 1.0 / sample_rate;
+    let n = ((t_end - t_start) / dt).floor() as usize + 1;
+    let mut result = Vec::with_capacity(n);
+
+    let mut j = 0usize;
+    for i in 0..n {
+        let t = t_start + i as f64 * dt;
+
+        // Advance j so that data[j].0 <= t < data[j+1].0
+        while j + 1 < data.len() && data[j + 1].0 <= t {
+            j += 1;
+        }
+
+        if j + 1 >= data.len() {
+            result.push(data.last().unwrap().1);
+        } else if t <= data[j].0 {
+            result.push(data[j].1);
+        } else {
+            let t0 = data[j].0;
+            let t1 = data[j + 1].0;
+            let v0 = data[j].1;
+            let v1 = data[j + 1].1;
+            let frac = (t - t0) / (t1 - t0);
+            result.push(v0 + frac * (v1 - v0));
+        }
+    }
+
+    result
+}
+
+/// Generate a Hanning (raised cosine) window of length `n`.
+pub fn hanning_window(n: usize) -> Vec<f64> {
+    (0..n)
+        .map(|i| 0.5 * (1.0 - (2.0 * PI * i as f64 / n as f64).cos()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resample_uniform_basic() {
+        let data = vec![(0.0, 1.0), (1.0, 3.0), (2.0, 5.0)];
+        let result = resample_uniform(&data, 2.0, 0.0, 2.0);
+        // At rate 2.0 Hz from 0 to 2: t = 0.0, 0.5, 1.0, 1.5, 2.0
+        assert_eq!(result.len(), 5);
+        assert!((result[0] - 1.0).abs() < 1e-9);
+        assert!((result[1] - 2.0).abs() < 1e-9);
+        assert!((result[2] - 3.0).abs() < 1e-9);
+        assert!((result[3] - 4.0).abs() < 1e-9);
+        assert!((result[4] - 5.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_hanning_window() {
+        let w = hanning_window(4);
+        assert_eq!(w.len(), 4);
+        assert!(w[0].abs() < 1e-10);
+        assert!((w[1] - 0.5).abs() < 1e-10);
+        assert!((w[2] - 1.0).abs() < 1e-10);
+        assert!((w[3] - 0.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_median_sample_rate() {
+        let data: Vec<(f64, f64)> = (0..100).map(|i| (i as f64 * 0.01, 0.0)).collect();
+        let rate = median_sample_rate(&data);
+        assert!((rate - 100.0).abs() < 1.0);
+    }
+
+    #[test]
+    fn test_median_sample_rate_empty() {
+        assert_eq!(median_sample_rate(&[]), 0.0);
+        assert_eq!(median_sample_rate(&[(0.0, 1.0)]), 0.0);
+    }
+}

--- a/crates/converter/src/signal_processing/mod.rs
+++ b/crates/converter/src/signal_processing/mod.rs
@@ -1,0 +1,219 @@
+//! Signal processing analysis framework.
+//!
+//! Provides a trait-based system for running signal processing analyses on
+//! ULog flight data. Unlike the streaming diagnostic analyzers, signal
+//! processing modules need full time-series vectors for FFT, spectral
+//! analysis, and deconvolution.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! Phase 1: Extract signals (single ULog pass)
+//!   → SignalStore { topic.field → Vec<(timestamp_s, value)> }
+//!
+//! Phase 2: Run analyses (per module, on extracted data)
+//!   → HashMap<module_id, JSON result>
+//! ```
+//!
+//! ## Adding a new analysis module
+//!
+//! 1. Create `crates/converter/src/signal_processing/your_module.rs`
+//! 2. Implement [`SignalAnalysis`] — declare signals, run analysis
+//! 3. Register in [`create_analyses()`]
+//! 4. Add tests following the pattern in [`testing`]
+
+use px4_ulog::stream_parser::file_reader::{
+    read_file_with_simple_callback, Message, SimpleCallbackResult,
+};
+use std::collections::{HashMap, HashSet};
+
+pub mod dsp;
+pub mod pid_step_response;
+#[cfg(test)]
+pub mod testing;
+
+// Re-export result types for backward compatibility
+pub use pid_step_response::{PidAnalysisResult, PidStepResponse, StepResponseHistogram};
+
+/// A time series of (timestamp_seconds, value) pairs.
+pub type TimeSeries = Vec<(f64, f64)>;
+
+/// Identifies a signal to extract from a ULog file.
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct SignalRequest {
+    pub topic: String,
+    pub field: String,
+}
+
+impl SignalRequest {
+    pub fn new(topic: &str, field: &str) -> Self {
+        Self {
+            topic: topic.to_string(),
+            field: field.to_string(),
+        }
+    }
+}
+
+/// Holds extracted time-series signals keyed by (topic, field).
+pub struct SignalStore {
+    signals: HashMap<SignalRequest, TimeSeries>,
+}
+
+impl SignalStore {
+    /// Get a signal by request. Returns an empty slice if the signal
+    /// was not found or had no data.
+    pub fn get(&self, request: &SignalRequest) -> &[(f64, f64)] {
+        self.signals
+            .get(request)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
+    }
+}
+
+/// Errors that can occur during signal processing analysis.
+#[derive(Debug, thiserror::Error)]
+pub enum AnalysisError {
+    #[error("insufficient data: {reason}")]
+    InsufficientData { reason: String },
+    #[error("processing error: {0}")]
+    Processing(String),
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+}
+
+/// Trait that all signal processing modules implement.
+pub trait SignalAnalysis: Send {
+    /// Machine-readable identifier (e.g., "pid_step_response").
+    fn id(&self) -> &str;
+
+    /// Short human-readable description.
+    fn description(&self) -> &str;
+
+    /// Which signals this analysis needs. The framework extracts these
+    /// from the ULog file in a single pass before calling `analyze()`.
+    fn required_signals(&self) -> Vec<SignalRequest>;
+
+    /// Run the analysis on extracted signals.
+    fn analyze(&self, signals: &SignalStore) -> Result<serde_json::Value, AnalysisError>;
+}
+
+/// Create all registered signal processing analyses.
+pub fn create_analyses() -> Vec<Box<dyn SignalAnalysis>> {
+    vec![Box::new(pid_step_response::PidStepResponseAnalysis)]
+}
+
+/// Create only the analyses whose IDs are in the given list.
+pub fn create_analyses_filtered(ids: &[String]) -> Result<Vec<Box<dyn SignalAnalysis>>, String> {
+    let all = create_analyses();
+    for id in ids {
+        if !all.iter().any(|a| a.id() == id.as_str()) {
+            let valid: Vec<&str> = all.iter().map(|a| a.id()).collect();
+            return Err(format!(
+                "unknown analysis '{}'. valid: {}",
+                id,
+                valid.join(", ")
+            ));
+        }
+    }
+    let selected = create_analyses()
+        .into_iter()
+        .filter(|a| ids.iter().any(|id| id == a.id()))
+        .collect();
+    Ok(selected)
+}
+
+/// Extract all requested signals from a ULog file in a single pass.
+pub fn extract_signals(
+    path: &str,
+    requests: &HashSet<SignalRequest>,
+) -> Result<SignalStore, std::io::Error> {
+    // Build a topic → Vec<field> lookup for fast dispatch
+    let mut topic_fields: HashMap<&str, Vec<&str>> = HashMap::new();
+    for req in requests {
+        topic_fields
+            .entry(req.topic.as_str())
+            .or_default()
+            .push(req.field.as_str());
+    }
+
+    let mut signals: HashMap<SignalRequest, TimeSeries> = requests
+        .iter()
+        .map(|r| (r.clone(), Vec::new()))
+        .collect();
+
+    read_file_with_simple_callback(path, &mut |msg| {
+        if let Message::Data(data) = msg {
+            let topic = data.flattened_format.message_name.as_str();
+
+            if let Some(fields) = topic_fields.get(topic) {
+                let ts = data
+                    .flattened_format
+                    .timestamp_field
+                    .as_ref()
+                    .map(|tf| tf.parse_timestamp(data.data));
+
+                if let Some(ts) = ts {
+                    let t_s = ts as f64 / 1_000_000.0;
+
+                    for &field in fields {
+                        if let Ok(parser) =
+                            data.flattened_format.get_field_parser::<f32>(field)
+                        {
+                            let val = parser.parse(data.data) as f64;
+                            if val.is_finite() {
+                                let key = SignalRequest::new(topic, field);
+                                if let Some(series) = signals.get_mut(&key) {
+                                    series.push((t_s, val));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        SimpleCallbackResult::KeepReading
+    })?;
+
+    // Sort each signal by timestamp
+    for series in signals.values_mut() {
+        series.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    }
+
+    Ok(SignalStore { signals })
+}
+
+/// Run selected analyses on a ULog file.
+///
+/// Extracts all required signals in a single pass, then runs each module.
+/// Modules that return `InsufficientData` are silently skipped.
+pub fn run_analyses(
+    path: &str,
+    analyses: &[Box<dyn SignalAnalysis>],
+) -> Result<HashMap<String, serde_json::Value>, AnalysisError> {
+    // Collect all required signals
+    let all_requests: HashSet<SignalRequest> = analyses
+        .iter()
+        .flat_map(|a| a.required_signals())
+        .collect();
+
+    // Single extraction pass
+    let store = extract_signals(path, &all_requests)?;
+
+    // Run each analysis
+    let mut results = HashMap::new();
+    for analysis in analyses {
+        match analysis.analyze(&store) {
+            Ok(result) => {
+                results.insert(analysis.id().to_string(), result);
+            }
+            Err(AnalysisError::InsufficientData { .. }) => {
+                // Silently skip — not all logs have all signals
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(results)
+}

--- a/crates/converter/src/signal_processing/pid_step_response.rs
+++ b/crates/converter/src/signal_processing/pid_step_response.rs
@@ -1,0 +1,414 @@
+//! PID step response analysis using Wiener deconvolution.
+//!
+//! Extracts the step response of the PID controller for each axis (roll,
+//! pitch, yaw) by deconvolving the rate setpoint (input) from the actual
+//! angular rate (output).
+
+use super::dsp::{hanning_window, median_sample_rate, resample_uniform};
+use super::{AnalysisError, SignalAnalysis, SignalRequest, SignalStore};
+use rustfft::num_complex::Complex;
+use rustfft::FftPlanner;
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PidStepResponse {
+    pub axis: String,
+    pub sample_rate_hz: f64,
+    pub window_count: usize,
+    /// Time points for the step response (0 to ~0.5s)
+    pub time_s: Vec<f64>,
+    /// Mean step response values (normalized, should approach 1.0)
+    pub mean_response: Vec<f64>,
+    /// 2D histogram: time_bins x amplitude_bins -> count
+    pub histogram: StepResponseHistogram,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StepResponseHistogram {
+    pub time_bins: Vec<f64>,
+    pub amplitude_bins: Vec<f64>,
+    /// Row-major: counts[time_idx * amplitude_bins.len() + amp_idx]
+    pub counts: Vec<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PidAnalysisResult {
+    pub axes: Vec<PidStepResponse>,
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const WINDOW_DURATION_S: f64 = 1.0;
+const STEP_DURATION_S: f64 = 0.5;
+const RESPONSE_DURATION_S: f64 = 0.5;
+const MIN_SAMPLE_RATE_HZ: f64 = 50.0;
+const MIN_WINDOWS: usize = 3;
+const NOISE_FLOOR_FACTOR: f64 = 1e-3;
+
+const HIST_TIME_BINS: usize = 100;
+const HIST_AMP_BINS: usize = 100;
+const HIST_AMP_MIN: f64 = -0.5;
+const HIST_AMP_MAX: f64 = 2.0;
+
+// ---------------------------------------------------------------------------
+// Axis mapping
+// ---------------------------------------------------------------------------
+
+const AXES: &[(&str, &str, &str)] = &[
+    ("roll", "roll", "xyz[0]"),
+    ("pitch", "pitch", "xyz[1]"),
+    ("yaw", "yaw", "xyz[2]"),
+];
+
+// ---------------------------------------------------------------------------
+// SignalAnalysis implementation
+// ---------------------------------------------------------------------------
+
+pub struct PidStepResponseAnalysis;
+
+impl SignalAnalysis for PidStepResponseAnalysis {
+    fn id(&self) -> &str {
+        "pid_step_response"
+    }
+
+    fn description(&self) -> &str {
+        "PID controller step response (Wiener deconvolution)"
+    }
+
+    fn required_signals(&self) -> Vec<SignalRequest> {
+        AXES.iter()
+            .flat_map(|(_, setpoint_field, gyro_field)| {
+                vec![
+                    SignalRequest::new("vehicle_rates_setpoint", setpoint_field),
+                    SignalRequest::new("vehicle_angular_velocity", gyro_field),
+                ]
+            })
+            .collect()
+    }
+
+    fn analyze(&self, signals: &SignalStore) -> Result<serde_json::Value, AnalysisError> {
+        let mut result = PidAnalysisResult { axes: Vec::new() };
+
+        for (axis_name, setpoint_field, gyro_field) in AXES {
+            let setpoint_req = SignalRequest::new("vehicle_rates_setpoint", setpoint_field);
+            let gyro_req = SignalRequest::new("vehicle_angular_velocity", gyro_field);
+
+            let setpoint_raw = signals.get(&setpoint_req);
+            let gyro_raw = signals.get(&gyro_req);
+
+            if let Some(response) = analyze_axis(axis_name, setpoint_raw, gyro_raw) {
+                result.axes.push(response);
+            }
+        }
+
+        if result.axes.is_empty() {
+            return Err(AnalysisError::InsufficientData {
+                reason: "no axis had sufficient data for PID analysis".to_string(),
+            });
+        }
+
+        serde_json::to_value(&result).map_err(AnalysisError::Serialization)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-axis analysis (now takes pre-extracted signals)
+// ---------------------------------------------------------------------------
+
+fn analyze_axis(
+    axis: &str,
+    setpoint_raw: &[(f64, f64)],
+    gyro_raw: &[(f64, f64)],
+) -> Option<PidStepResponse> {
+    if setpoint_raw.len() < 2 || gyro_raw.len() < 2 {
+        return None;
+    }
+
+    let sample_rate = median_sample_rate(setpoint_raw);
+    if sample_rate < MIN_SAMPLE_RATE_HZ {
+        return None;
+    }
+
+    let t_start = setpoint_raw[0].0.max(gyro_raw[0].0);
+    let t_end = setpoint_raw.last().unwrap().0.min(gyro_raw.last().unwrap().0);
+    if t_end - t_start < WINDOW_DURATION_S {
+        return None;
+    }
+
+    let setpoint = resample_uniform(setpoint_raw, sample_rate, t_start, t_end);
+    let gyro = resample_uniform(gyro_raw, sample_rate, t_start, t_end);
+
+    let n = setpoint.len().min(gyro.len());
+    if n < 2 {
+        return None;
+    }
+    let setpoint = &setpoint[..n];
+    let gyro = &gyro[..n];
+
+    let window_samples = (WINDOW_DURATION_S * sample_rate).round() as usize;
+    let step_samples = (STEP_DURATION_S * sample_rate).round() as usize;
+    let response_samples = (RESPONSE_DURATION_S * sample_rate).round() as usize;
+
+    if window_samples < 4 || step_samples == 0 || response_samples == 0 {
+        return None;
+    }
+
+    let hann = hanning_window(window_samples);
+    let mut all_step_responses: Vec<Vec<f64>> = Vec::new();
+
+    let mut offset = 0;
+    while offset + window_samples <= n {
+        let sp_win = &setpoint[offset..offset + window_samples];
+        let gy_win = &gyro[offset..offset + window_samples];
+
+        if let Some(step) =
+            wiener_step_response(sp_win, gy_win, &hann, window_samples, response_samples)
+        {
+            all_step_responses.push(step);
+        }
+
+        offset += step_samples;
+    }
+
+    if all_step_responses.len() < MIN_WINDOWS {
+        return None;
+    }
+
+    let resp_len = response_samples.min(
+        all_step_responses
+            .iter()
+            .map(|r| r.len())
+            .min()
+            .unwrap_or(0),
+    );
+    if resp_len == 0 {
+        return None;
+    }
+
+    let mut mean_response = vec![0.0f64; resp_len];
+    for resp in &all_step_responses {
+        for (i, &v) in resp.iter().take(resp_len).enumerate() {
+            mean_response[i] += v;
+        }
+    }
+    let count = all_step_responses.len() as f64;
+    for v in &mut mean_response {
+        *v /= count;
+    }
+
+    let dt = 1.0 / sample_rate;
+    let time_s: Vec<f64> = (0..resp_len).map(|i| i as f64 * dt).collect();
+
+    let histogram = build_histogram(&all_step_responses, resp_len, &time_s);
+
+    Some(PidStepResponse {
+        axis: axis.to_string(),
+        sample_rate_hz: sample_rate,
+        window_count: all_step_responses.len(),
+        time_s,
+        mean_response,
+        histogram,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Wiener deconvolution
+// ---------------------------------------------------------------------------
+
+fn wiener_step_response(
+    input: &[f64],
+    output: &[f64],
+    hann: &[f64],
+    fft_len: usize,
+    response_len: usize,
+) -> Option<Vec<f64>> {
+    let mut x: Vec<Complex<f64>> = input
+        .iter()
+        .zip(hann.iter())
+        .map(|(&s, &w)| Complex::new(s * w, 0.0))
+        .collect();
+    let mut y: Vec<Complex<f64>> = output
+        .iter()
+        .zip(hann.iter())
+        .map(|(&s, &w)| Complex::new(s * w, 0.0))
+        .collect();
+
+    x.resize(fft_len, Complex::new(0.0, 0.0));
+    y.resize(fft_len, Complex::new(0.0, 0.0));
+
+    let mut planner = FftPlanner::<f64>::new();
+    let fft = planner.plan_fft_forward(fft_len);
+    fft.process(&mut x);
+    fft.process(&mut y);
+
+    let max_power = x
+        .iter()
+        .map(|c| c.norm_sqr())
+        .fold(0.0f64, |a, b| a.max(b));
+    if max_power < 1e-30 {
+        return None;
+    }
+    let noise_floor = max_power * NOISE_FLOOR_FACTOR;
+
+    let mut h: Vec<Complex<f64>> = y
+        .iter()
+        .zip(x.iter())
+        .map(|(yi, xi)| {
+            let denom = xi.norm_sqr() + noise_floor;
+            (*yi * xi.conj()) / denom
+        })
+        .collect();
+
+    let ifft = planner.plan_fft_inverse(fft_len);
+    ifft.process(&mut h);
+
+    let scale = 1.0 / fft_len as f64;
+
+    let resp_len = response_len.min(fft_len);
+    let mut step = Vec::with_capacity(resp_len);
+    let mut cumsum = 0.0;
+    for item in h.iter().take(resp_len) {
+        let impulse_val = item.re * scale;
+        if impulse_val.is_finite() {
+            cumsum += impulse_val;
+        }
+        step.push(cumsum);
+    }
+
+    let final_val = *step.last().unwrap_or(&0.0);
+    if final_val.abs() < 1e-10 {
+        return None;
+    }
+    for v in &mut step {
+        *v /= final_val;
+    }
+
+    Some(step)
+}
+
+// ---------------------------------------------------------------------------
+// Histogram
+// ---------------------------------------------------------------------------
+
+fn build_histogram(
+    all_responses: &[Vec<f64>],
+    resp_len: usize,
+    time_s: &[f64],
+) -> StepResponseHistogram {
+    let time_min = 0.0f64;
+    let time_max = RESPONSE_DURATION_S;
+    let time_bin_width = (time_max - time_min) / HIST_TIME_BINS as f64;
+    let amp_bin_width = (HIST_AMP_MAX - HIST_AMP_MIN) / HIST_AMP_BINS as f64;
+
+    let time_bins: Vec<f64> = (0..HIST_TIME_BINS)
+        .map(|i| time_min + (i as f64 + 0.5) * time_bin_width)
+        .collect();
+    let amplitude_bins: Vec<f64> = (0..HIST_AMP_BINS)
+        .map(|i| HIST_AMP_MIN + (i as f64 + 0.5) * amp_bin_width)
+        .collect();
+
+    let mut counts = vec![0u32; HIST_TIME_BINS * HIST_AMP_BINS];
+
+    for resp in all_responses {
+        for (i, &val) in resp.iter().take(resp_len).enumerate() {
+            if i >= time_s.len() {
+                break;
+            }
+            let t = time_s[i];
+            let ti = ((t - time_min) / time_bin_width).floor() as isize;
+            let ai = ((val - HIST_AMP_MIN) / amp_bin_width).floor() as isize;
+
+            if ti >= 0
+                && (ti as usize) < HIST_TIME_BINS
+                && ai >= 0
+                && (ai as usize) < HIST_AMP_BINS
+            {
+                counts[ti as usize * HIST_AMP_BINS + ai as usize] += 1;
+            }
+        }
+    }
+
+    StepResponseHistogram {
+        time_bins,
+        amplitude_bins,
+        counts,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::signal_processing::dsp::hanning_window;
+    use crate::signal_processing::testing;
+
+    #[test]
+    fn test_pid_analysis_sample() {
+        let result = testing::analyze_fixture_for("sample.ulg", "pid_step_response");
+        // sample.ulg may not have vehicle_angular_velocity, so PID analysis
+        // may return InsufficientData (None here). That's valid.
+        let Some(value) = result else {
+            return;
+        };
+
+        let parsed: PidAnalysisResult = serde_json::from_value(value).unwrap();
+
+        for axis_result in &parsed.axes {
+            assert!(
+                axis_result.sample_rate_hz >= MIN_SAMPLE_RATE_HZ,
+                "sample rate should be above minimum"
+            );
+            assert!(
+                axis_result.window_count >= MIN_WINDOWS,
+                "should have enough windows"
+            );
+            assert!(!axis_result.time_s.is_empty());
+            assert_eq!(axis_result.time_s.len(), axis_result.mean_response.len());
+            assert_eq!(axis_result.histogram.time_bins.len(), HIST_TIME_BINS);
+            assert_eq!(axis_result.histogram.amplitude_bins.len(), HIST_AMP_BINS);
+            assert_eq!(
+                axis_result.histogram.counts.len(),
+                HIST_TIME_BINS * HIST_AMP_BINS
+            );
+        }
+    }
+
+    #[test]
+    fn test_pid_analysis_fixed_wing() {
+        let result = testing::analyze_fixture_for("fixed_wing_gps.ulg", "pid_step_response");
+        // May or may not produce a result depending on log content
+        if let Some(value) = result {
+            let parsed: PidAnalysisResult = serde_json::from_value(value).unwrap();
+            for axis_result in &parsed.axes {
+                assert!(axis_result.window_count >= MIN_WINDOWS);
+                assert!(!axis_result.mean_response.is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn test_wiener_step_response_identity() {
+        let n = 128;
+        let hann = hanning_window(n);
+        let signal: Vec<f64> = (0..n).map(|i| (i as f64 * 0.1).sin()).collect();
+        let resp = wiener_step_response(&signal, &signal, &hann, n, n / 2);
+        if let Some(r) = resp {
+            assert!(!r.is_empty());
+            assert!((r.last().unwrap() - 1.0).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn test_no_errors_on_fixtures() {
+        testing::assert_no_errors("sample.ulg", "pid_step_response");
+    }
+}

--- a/crates/converter/src/signal_processing/testing.rs
+++ b/crates/converter/src/signal_processing/testing.rs
@@ -1,0 +1,89 @@
+//! Test framework for signal processing modules.
+//!
+//! Provides fixture helpers for running analyses against real ULog files.
+//!
+//! ## Required test categories for every module
+//!
+//! 1. **No errors** — `assert_no_errors("sample.ulg", "<id>")`
+//! 2. **Produces result** — verify output on a known-good fixture
+//! 3. **Handles missing signals** — returns `InsufficientData`, not panic
+//! 4. **Snapshot test** — `insta::assert_json_snapshot!` for CI diffing
+
+use std::collections::HashMap;
+
+/// Resolve a test fixture path by name.
+pub fn fixture_path(name: &str) -> String {
+    let manifest = env!("CARGO_MANIFEST_DIR");
+
+    let local = std::path::Path::new(manifest)
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("crates/converter/tests/fixtures")
+        .join(name);
+    if local.exists() {
+        return local.to_string_lossy().to_string();
+    }
+
+    let external = std::path::Path::new(manifest)
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("px4-ulog-rs/tests/fixtures")
+        .join(name);
+    external.to_string_lossy().to_string()
+}
+
+/// Run all registered analyses on a fixture file.
+pub fn analyze_fixture(name: &str) -> HashMap<String, serde_json::Value> {
+    let path = fixture_path(name);
+    assert!(
+        std::path::Path::new(&path).exists(),
+        "Test fixture not found: {}",
+        path
+    );
+    let analyses = super::create_analyses();
+    super::run_analyses(&path, &analyses).unwrap_or_default()
+}
+
+/// Run all analyses and return the result for a specific module.
+pub fn analyze_fixture_for(name: &str, analysis_id: &str) -> Option<serde_json::Value> {
+    let path = fixture_path(name);
+    if !std::path::Path::new(&path).exists() {
+        return None;
+    }
+    let analyses = super::create_analyses();
+    let results = super::run_analyses(&path, &analyses).unwrap_or_default();
+    results.get(analysis_id).cloned()
+}
+
+/// Assert that an analysis produces a non-empty result on a fixture.
+pub fn assert_produces_result(fixture: &str, analysis_id: &str) {
+    let result = analyze_fixture_for(fixture, analysis_id);
+    assert!(
+        result.is_some(),
+        "Expected '{}' to produce a result on {}, but got None",
+        analysis_id,
+        fixture
+    );
+}
+
+/// Assert that running analyses on a fixture does not error or panic.
+pub fn assert_no_errors(fixture: &str, analysis_id: &str) {
+    let path = fixture_path(fixture);
+    if !std::path::Path::new(&path).exists() {
+        eprintln!("Skipping: {} not available", fixture);
+        return;
+    }
+    let analyses = super::create_analyses();
+    let filtered: Vec<_> = analyses
+        .into_iter()
+        .filter(|a| a.id() == analysis_id)
+        .collect();
+    // Should not panic or return a hard error
+    let _ = super::run_analyses(&path, &filtered);
+}


### PR DESCRIPTION
Adds a general signal processing framework to the converter crate and unifies the CLI batch processing commands.

The signal processing framework uses a two-phase architecture: extract all required signals from the ULog file in a single pass into a `SignalStore`, then run each analysis module on the buffered time series. This is fundamentally different from diagnostics (which are streaming) because signal processing needs full vectors for FFT, spectral analysis, and deconvolution. PID step response analysis is refactored as the first module — it now reads the file once instead of three times (once per axis).

The CLI replaces the `scan` subcommand with a unified `batch` command that handles conversion, diagnostics, and signal processing in one parallel pass:

```
ulog-convert batch dir/ -o output/                        # convert to Parquet
ulog-convert batch dir/ --diagnostics-only                # scan for anomalies
ulog-convert batch dir/ -o out/ --diagnostics --analyze   # everything
ulog-convert analyze flight.ulg                           # single-file signal processing
```

Shared DSP utilities (resampling, windowing, sample rate estimation) are extracted into `signal_processing/dsp.rs` for reuse by future modules. The existing `pid_analysis()` function remains as a backward-compatible facade — `--pid-analysis` still works.

Adding a new signal processing module follows the same pattern as diagnostics: implement the `SignalAnalysis` trait, declare required signals, register in the factory. The test framework mirrors `diagnostics/testing.rs`.