### PR TITLE
fix: lazy-load plots and mobile UI improvements

### DIFF
--- a/frontend/src/lib/components/browse/LogTable.svelte
+++ b/frontend/src/lib/components/browse/LogTable.svelte
@@ -99,8 +99,8 @@
 								>
 									{#if col.key === 'vehicle_type'}
 										<div class="flex items-center gap-2">
-											<img src={vehicleIconPath(log.vehicle_type)} alt="" class="size-6 opacity-60" />
-											<span class="font-medium text-gray-900">{log.vehicle_type || log.sys_name || '\u2014'}</span>
+											<img src={vehicleIconPath(log.vehicle_type)} alt={log.vehicle_type ?? ''} class="size-6 opacity-60" />
+											<span class="hidden sm:inline font-medium text-gray-900">{log.vehicle_type || log.sys_name || '\u2014'}</span>
 										</div>
 									{:else if col.key === 'location_name'}
 										{#if loc}

--- a/frontend/src/lib/components/viewer/DragDropPlotList.svelte
+++ b/frontend/src/lib/components/viewer/DragDropPlotList.svelte
@@ -2,6 +2,7 @@
 	import type { PlotConfig, FlightMetadata } from '$lib/types';
 	import { reorderPlots } from '$lib/stores/logViewer';
 	import PlotStrip from './PlotStrip.svelte';
+	import LazyPlot from './LazyPlot.svelte';
 
 	let { plots, logId, metadata } = $props<{
 		plots: PlotConfig[];
@@ -72,17 +73,19 @@
 			{#if dropTargetIndex === i && dragFromIndex !== null && dragFromIndex !== i}
 				<div class="absolute -top-px left-0 right-0 h-0.5 bg-blue-500 z-10 rounded-full"></div>
 			{/if}
-			<PlotStrip
-				config={plot}
-				{logId}
-				{metadata}
-				index={i}
-				totalCount={plots.length}
-				onMoveUp={() => moveUp(i)}
-				onMoveDown={() => moveDown(i)}
-				onDragStart={handleDragStart(i)}
-				onDragEnd={handleDragEnd}
-			/>
+			<LazyPlot>
+				<PlotStrip
+					config={plot}
+					{logId}
+					{metadata}
+					index={i}
+					totalCount={plots.length}
+					onMoveUp={() => moveUp(i)}
+					onMoveDown={() => moveDown(i)}
+					onDragStart={handleDragStart(i)}
+					onDragEnd={handleDragEnd}
+				/>
+			</LazyPlot>
 		</div>
 	{/each}
 </div>

--- a/frontend/src/lib/components/viewer/LazyPlot.svelte
+++ b/frontend/src/lib/components/viewer/LazyPlot.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+
+	let { children, height = 220 } = $props<{
+		children: import('svelte').Snippet;
+		height?: number;
+	}>();
+
+	let sentinel = $state<HTMLDivElement>();
+	let visible = $state(false);
+	let observer: IntersectionObserver | null = null;
+
+	onMount(() => {
+		if (!sentinel) return;
+		observer = new IntersectionObserver(
+			([entry]) => {
+				if (entry.isIntersecting) {
+					visible = true;
+					// Once visible, stop observing — keep mounted so canvas isn't destroyed/recreated
+					observer?.disconnect();
+					observer = null;
+				}
+			},
+			{ rootMargin: '200px 0px' } // start loading 200px before entering viewport
+		);
+		observer.observe(sentinel);
+	});
+
+	onDestroy(() => {
+		observer?.disconnect();
+	});
+</script>
+
+<div bind:this={sentinel}>
+	{#if visible}
+		{@render children()}
+	{:else}
+		<div
+			class="rounded-lg ring-1 ring-gray-200 bg-white flex items-center justify-center"
+			style="height: {height}px;"
+		>
+			<span class="text-xs text-gray-400">Scroll to load</span>
+		</div>
+	{/if}
+</div>

--- a/frontend/src/lib/components/viewer/PlotStrip.svelte
+++ b/frontend/src/lib/components/viewer/PlotStrip.svelte
@@ -5,6 +5,7 @@
 	import { activePlots, togglePlotMinimized } from '$lib/stores/logViewer';
 	import { timeRange, cursorTimestamp, SYNC_KEY } from '$lib/stores/plotSync';
 	import { initDuckDB, LogSession } from '$lib/utils/duckdb';
+	import { touchZoomPlugin } from '$lib/utils/uplotTouchZoom';
 
 	let { config, logId, metadata, index, totalCount, onMoveUp, onMoveDown, onDragStart, onDragEnd } = $props<{
 		config: PlotConfig;
@@ -97,8 +98,10 @@
 			const opts: uPlot.Options = {
 				width: containerWidth,
 				height: plotHeight,
+				plugins: [touchZoomPlugin()],
 				cursor: {
 					sync: { key: SYNC_KEY, setSeries: true },
+					drag: { x: true, y: false, setScale: true },
 				},
 				scales: {
 					x: { time: false },
@@ -322,6 +325,6 @@
 				</div>
 			</div>
 		{/if}
-		<div bind:this={chartEl}></div>
+		<div bind:this={chartEl} class="touch-action-none" style="touch-action: none;"></div>
 	</div>
 </div>

--- a/frontend/src/lib/utils/uplotTouchZoom.ts
+++ b/frontend/src/lib/utils/uplotTouchZoom.ts
@@ -1,0 +1,125 @@
+/**
+ * uPlot touch-zoom plugin — pinch-to-zoom and single-finger pan on the x-axis.
+ *
+ * Adapted from the official uPlot zoom-touch demo by Leon Sorokin:
+ * https://github.com/leeoniya/uPlot/blob/master/demos/zoom-touch.html
+ *
+ * Changes from original:
+ * - X-axis only (y-axis is left untouched)
+ * - TypeScript types
+ * - Cleanup on destroy
+ */
+
+import type uPlot from 'uplot';
+
+interface Pos {
+	x: number;
+	y: number;
+	d: number;
+	dx: number;
+	dy: number;
+}
+
+export function touchZoomPlugin(): uPlot.Plugin {
+	function init(u: uPlot) {
+		const over = u.over;
+		let rect: DOMRect;
+		let oxRange: number;
+		let xVal: number;
+
+		const fr: Pos = { x: 0, y: 0, d: 1, dx: 0, dy: 0 };
+		const to: Pos = { x: 0, y: 0, d: 1, dx: 0, dy: 0 };
+
+		function storePos(t: Pos, e: TouchEvent) {
+			const ts = e.touches;
+			const t0 = ts[0];
+			const t0x = t0.clientX - rect.left;
+			const t0y = t0.clientY - rect.top;
+
+			if (ts.length === 1) {
+				t.x = t0x;
+				t.y = t0y;
+				t.d = t.dx = t.dy = 1;
+			} else {
+				const t1 = ts[1];
+				const t1x = t1.clientX - rect.left;
+				const t1y = t1.clientY - rect.top;
+
+				const xMin = Math.min(t0x, t1x);
+				const xMax = Math.max(t0x, t1x);
+				const yMin = Math.min(t0y, t1y);
+				const yMax = Math.max(t0y, t1y);
+
+				t.x = (xMin + xMax) / 2;
+				t.y = (yMin + yMax) / 2;
+				t.dx = xMax - xMin;
+				t.dy = yMax - yMin;
+				t.d = Math.sqrt(t.dx * t.dx + t.dy * t.dy);
+			}
+		}
+
+		let rafPending = false;
+
+		function zoom() {
+			rafPending = false;
+
+			const left = to.x;
+
+			// For single-finger pan: d stays 1, so xFactor = 1 — only the
+			// position shift (leftPct difference) moves the viewport.
+			// For pinch: d changes, producing a zoom factor.
+			const xFactor = fr.d / to.d;
+			const leftPct = left / rect.width;
+
+			const nxRange = oxRange * xFactor;
+			const nxMin = xVal - leftPct * nxRange;
+			const nxMax = nxMin + nxRange;
+
+			u.setScale('x', { min: nxMin, max: nxMax });
+		}
+
+		function touchmove(e: TouchEvent) {
+			storePos(to, e);
+
+			if (!rafPending) {
+				rafPending = true;
+				requestAnimationFrame(zoom);
+			}
+		}
+
+		function touchstart(e: TouchEvent) {
+			rect = over.getBoundingClientRect();
+			storePos(fr, e);
+
+			oxRange = (u.scales.x.max ?? 0) - (u.scales.x.min ?? 0);
+			xVal = u.posToVal(fr.x, 'x');
+
+			document.addEventListener('touchmove', touchmove, { passive: true });
+		}
+
+		function touchend() {
+			document.removeEventListener('touchmove', touchmove);
+		}
+
+		over.addEventListener('touchstart', touchstart, { passive: true });
+		over.addEventListener('touchend', touchend);
+
+		// Store refs for cleanup
+		(u as any)._touchZoom = { touchstart, touchend };
+	}
+
+	function destroy(u: uPlot) {
+		const refs = (u as any)._touchZoom;
+		if (refs) {
+			u.over.removeEventListener('touchstart', refs.touchstart);
+			u.over.removeEventListener('touchend', refs.touchend);
+		}
+	}
+
+	return {
+		hooks: {
+			init: [init],
+			destroy: [destroy],
+		},
+	};
+}

--- a/frontend/src/routes/log/[id]/+layout.svelte
+++ b/frontend/src/routes/log/[id]/+layout.svelte
@@ -51,6 +51,12 @@
 	});
 
 	onDestroy(() => {
+		// Clear the per-log session cache so closed LogSessions don't linger
+		const cache: Map<string, any> | undefined = (globalThis as any).__plotSessionCache;
+		if (cache) {
+			for (const session of cache.values()) session.close();
+			cache.clear();
+		}
 		terminateDuckDB();
 	});
 

--- a/frontend/src/routes/log/[id]/+layout.svelte
+++ b/frontend/src/routes/log/[id]/+layout.svelte
@@ -147,23 +147,23 @@
 						<div class="ml-auto flex items-center gap-2">
 							{#if activeTab === ''}
 								<button
-									class="flex items-center gap-1.5 rounded-md bg-indigo-600 px-3 py-1 text-xs font-medium text-white hover:bg-indigo-500"
+									class="flex items-center gap-1.5 rounded-md bg-indigo-600 px-2 sm:px-3 py-1 text-xs font-medium text-white hover:bg-indigo-500"
 									onclick={() => builderOpen.set(true)}
 								>
 									<svg class="size-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
 										<path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 010 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 010-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28z" />
 										<path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
 									</svg>
-									Edit Plots
+									<span class="hidden sm:inline">Edit Plots</span>
 								</button>
 								<button
-									class="flex items-center gap-1.5 rounded-md bg-white px-3 py-1 text-xs font-medium text-gray-700 ring-1 ring-gray-300 hover:bg-gray-50"
+									class="flex items-center gap-1.5 rounded-md bg-white px-2 sm:px-3 py-1 text-xs font-medium text-gray-700 ring-1 ring-gray-300 hover:bg-gray-50"
 									onclick={resetZoom}
 								>
 									<svg class="size-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
 										<path stroke-linecap="round" stroke-linejoin="round" d="M9 9V4.5M9 9H4.5M9 9L3.75 3.75M9 15v4.5M9 15H4.5M9 15l-5.25 5.25M15 9h4.5M15 9V4.5M15 9l5.25-5.25M15 15h4.5M15 15v4.5m0-4.5l5.25 5.25" />
 									</svg>
-									Reset Zoom
+									<span class="hidden sm:inline">Reset Zoom</span>
 								</button>
 							{/if}
 						</div>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,50 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vitest/config';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Plugin } from 'vite';
+
+/**
+ * Serve DuckDB worker source-map files from node_modules during dev.
+ *
+ * The DuckDB WASM worker is loaded via a blob URL (fetched from a CDN).
+ * The worker script contains a `//# sourceMappingURL=<file>.map` comment,
+ * which the browser resolves relative to the page origin, hitting the Vite
+ * dev server and producing a 404. This plugin intercepts those requests and
+ * serves the corresponding .map file from the installed package.
+ */
+function duckdbWorkerSourcemaps(): Plugin {
+  const DUCKDB_MAP_RE = /^\/(duckdb-browser-.+\.worker\.js\.map)$/;
+  const distDir = join(
+    __dirname,
+    'node_modules',
+    '@duckdb',
+    'duckdb-wasm',
+    'dist',
+  );
+
+  return {
+    name: 'duckdb-worker-sourcemaps',
+    apply: 'serve', // dev only
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const match = req.url && DUCKDB_MAP_RE.exec(req.url);
+        if (!match) return next();
+        try {
+          const content = readFileSync(join(distDir, match[1]));
+          res.setHeader('Content-Type', 'application/json');
+          res.end(content);
+        } catch {
+          next();
+        }
+      });
+    },
+  };
+}
 
 export default defineConfig({
-  plugins: [tailwindcss(), sveltekit()],
+  plugins: [duckdbWorkerSourcemaps(), tailwindcss(), sveltekit()],
   server: {
     proxy: {
       '/api': {


### PR DESCRIPTION
Fixes mobile browser crashes when loading the log viewer by lazy-loading plots with IntersectionObserver — only plots near the viewport are mounted, instead of all ~25 at once. This avoids hitting iOS canvas memory limits and flooding DuckDB WASM with concurrent queries.

Also fixes the DuckDB session cache leak (connections from previously viewed logs were never cleaned up) and adds several mobile UI polish items:

- Icon-only "Edit Plots" and "Reset Zoom" buttons on small screens
- Icon-only vehicle type in the browse table on mobile
- Dev-only Vite plugin to serve DuckDB worker source maps (eliminates 404 noise in dev console, no effect on production)