### PR TITLE
ci: expand release workflow and update px4-ulog dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,18 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 env:
   CARGO_TERM_COLOR: always
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
+  # ---------------------------------------------------------------------------
+  # 1. Build CLI + server binaries for all platforms
+  # ---------------------------------------------------------------------------
+  build-binaries:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -47,32 +53,146 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
-      - name: Build
-        run: cargo build --release --target ${{ matrix.target }} -p flight-review
+      - name: Build CLI and server
+        run: |
+          cargo build --release --target ${{ matrix.target }} -p flight-review
+          cargo build --release --target ${{ matrix.target }} -p flight-review-server
 
       - name: Package (unix)
         if: runner.os != 'Windows'
         run: |
           cd target/${{ matrix.target }}/release
           tar czf ../../../ulog-convert-${{ matrix.target }}.tar.gz ulog-convert
-          cd ../../..
+          tar czf ../../../flight-review-server-${{ matrix.target }}.tar.gz flight-review-server
 
       - name: Package (windows)
         if: runner.os == 'Windows'
         run: |
           cd target/${{ matrix.target }}/release
           7z a ../../../ulog-convert-${{ matrix.target }}.zip ulog-convert.exe
-          cd ../../..
+          7z a ../../../flight-review-server-${{ matrix.target }}.zip flight-review-server.exe
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-${{ matrix.target }}
+          path: |
+            ulog-convert-${{ matrix.target }}.*
+            flight-review-server-${{ matrix.target }}.*
+
+  # ---------------------------------------------------------------------------
+  # 2. Build frontend static assets
+  # ---------------------------------------------------------------------------
+  build-frontend:
+    name: Build Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install and build
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Package
+        run: tar czf flight-review-frontend.tar.gz -C frontend/build .
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ulog-convert-${{ matrix.target }}
-          path: ulog-convert-${{ matrix.target }}.*
+          name: frontend
+          path: flight-review-frontend.tar.gz
 
+  # ---------------------------------------------------------------------------
+  # 3. Publish crates to crates.io (requires CARGO_REGISTRY_TOKEN secret)
+  # ---------------------------------------------------------------------------
+  publish-crates:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    # Disabled until px4-ulog dependency is on crates.io.
+    # Remove the 'if: false' once the git dependency is replaced with a
+    # crates.io version.
+    if: false
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Publish flight-review
+        run: cargo publish -p flight-review
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish flight-review-server
+        run: cargo publish -p flight-review-server
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # ---------------------------------------------------------------------------
+  # 4. Build and push Docker image to GHCR
+  # ---------------------------------------------------------------------------
+  docker:
+    name: Docker (GHCR)
+    runs-on: ubuntu-latest
+    needs: build-frontend
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download frontend build
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend
+          path: .
+
+      - name: Extract frontend into server static dir
+        run: |
+          mkdir -p frontend/build
+          tar xzf flight-review-frontend.tar.gz -C frontend/build
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ---------------------------------------------------------------------------
+  # 5. Create GitHub Release with all artifacts
+  # ---------------------------------------------------------------------------
   release:
     name: Create Release
-    needs: build
+    needs: [build-binaries, build-frontend]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -86,7 +206,7 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts
-          sha256sum ulog-convert-* > sha256sums.txt
+          sha256sum *.tar.gz *.zip 2>/dev/null > sha256sums.txt
           cat sha256sums.txt
 
       - name: Create GitHub Release
@@ -96,4 +216,7 @@ jobs:
           files: |
             artifacts/ulog-convert-*.tar.gz
             artifacts/ulog-convert-*.zip
+            artifacts/flight-review-server-*.tar.gz
+            artifacts/flight-review-server-*.zip
+            artifacts/flight-review-frontend.tar.gz
             artifacts/sha256sums.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,7 +2314,7 @@ dependencies = [
 [[package]]
 name = "px4-ulog"
 version = "0.1.1"
-source = "git+https://github.com/mrpollo/px4-ulog-rs.git?branch=test%2Fcomprehensive-test-coverage#95514a6f610e79f3971a89a5a1a4ea04e505143a"
+source = "git+https://github.com/PX4/px4-ulog-rs.git#1fbe2082589d25e3bc3e67a966c377e52cee3b31"
 dependencies = [
  "byteorder",
 ]

--- a/crates/converter/Cargo.toml
+++ b/crates/converter/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["px4", "ulog", "parquet", "flight-review", "drone"]
 categories = ["science", "command-line-utilities", "parser-implementations"]
 
 [dependencies]
-px4-ulog = { git = "https://github.com/mrpollo/px4-ulog-rs.git", branch = "test/comprehensive-test-coverage" }
+px4-ulog = { git = "https://github.com/PX4/px4-ulog-rs.git" }
 arrow = "54"
 parquet = { version = "54", features = ["arrow"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Expands the release workflow to cover all monorepo components on tag push (`v*`):

- **CLI + Server binaries**: Builds `ulog-convert` and `flight-review-server` for Linux (x86_64, aarch64), macOS (aarch64), and Windows (x86_64)
- **Frontend**: Builds SvelteKit static assets and attaches as a tarball
- **Docker**: Builds and pushes image to GHCR with semver tags
- **crates.io**: Publish job for both crates (disabled until `px4-ulog` is available on crates.io)

Also updates the `px4-ulog` dependency from `mrpollo/px4-ulog-rs` (branch) to `PX4/px4-ulog-rs` (main).