### PR TITLE
perf: optimize plot sync and add desktop zoom/pan

### DIFF
--- a/frontend/src/lib/components/viewer/PlotStrip.svelte
+++ b/frontend/src/lib/components/viewer/PlotStrip.svelte
@@ -3,7 +3,7 @@
 	import uPlot from 'uplot';
 	import type { PlotConfig, FlightMetadata } from '$lib/types';
 	import { activePlots, togglePlotMinimized } from '$lib/stores/logViewer';
-	import { timeRange, cursorTimestamp, SYNC_KEY } from '$lib/stores/plotSync';
+	import { timeRange, setTimeRange, cursorTimestamp, SYNC_KEY } from '$lib/stores/plotSync';
 	import { initDuckDB, LogSession } from '$lib/utils/duckdb';
 	import { touchZoomPlugin } from '$lib/utils/uplotTouchZoom';
 
@@ -33,6 +33,11 @@
 
 	// Guard against infinite loops when syncing scales
 	let settingScale = false;
+
+	// Track whether this plot is visible in the viewport
+	let isVisible = $state(true);
+	let pendingSyncRange: [number, number] | null = null;
+	let intersectionObserver: IntersectionObserver | null = null;
 
 	// Track the fields key to detect changes
 	let lastFieldsKey = '';
@@ -124,7 +129,7 @@
 							const min = u.scales.x.min;
 							const max = u.scales.x.max;
 							if (min != null && max != null) {
-								timeRange.set([min, max]);
+								setTimeRange(min, max);
 							}
 						},
 					],
@@ -159,7 +164,31 @@
 		}
 	}
 
+	function applyPendingRange() {
+		if (!uplot || !pendingSyncRange) return;
+		settingScale = true;
+		uplot.setScale('x', { min: pendingSyncRange[0], max: pendingSyncRange[1] });
+		settingScale = false;
+		pendingSyncRange = null;
+	}
+
 	onMount(() => {
+		// Track visibility to skip off-screen redraws
+		if (containerEl) {
+			intersectionObserver = new IntersectionObserver(
+				(entries) => {
+					for (const entry of entries) {
+						isVisible = entry.isIntersecting;
+						if (isVisible) {
+							applyPendingRange();
+						}
+					}
+				},
+				{ rootMargin: '100px' } // slight margin so plots update just before scrolling into view
+			);
+			intersectionObserver.observe(containerEl);
+		}
+
 		// Setup resize observer
 		if (containerEl) {
 			resizeObserver = new ResizeObserver((entries) => {
@@ -191,15 +220,22 @@
 		}
 	});
 
-	// React to timeRange changes from other plots
+	// React to timeRange changes from other plots.
+	// Off-screen plots stash the range and apply it when they become visible.
 	$effect(() => {
 		const range = $timeRange;
 		if (!uplot || settingScale) return;
+
+		if (!isVisible) {
+			// Stash for later — will be applied when plot scrolls into view
+			pendingSyncRange = range ? [range[0], range[1]] : null;
+			return;
+		}
+
 		settingScale = true;
 		if (range) {
 			uplot.setScale('x', { min: range[0], max: range[1] });
 		} else {
-			// Reset zoom: let uPlot auto-fit to full data range
 			const data = uplot.data;
 			if (data && data[0] && data[0].length > 0) {
 				uplot.setScale('x', { min: data[0][0], max: data[0][data[0].length - 1] });
@@ -216,6 +252,10 @@
 		if (resizeObserver) {
 			resizeObserver.disconnect();
 			resizeObserver = null;
+		}
+		if (intersectionObserver) {
+			intersectionObserver.disconnect();
+			intersectionObserver = null;
 		}
 	});
 </script>

--- a/frontend/src/lib/stores/plotSync.ts
+++ b/frontend/src/lib/stores/plotSync.ts
@@ -3,3 +3,23 @@ import { writable } from 'svelte/store';
 export const timeRange = writable<[number, number] | null>(null);
 export const cursorTimestamp = writable<number | null>(null);
 export const SYNC_KEY = 'flight-review-sync';
+
+/**
+ * Throttled write to timeRange — ensures synced plots update at most
+ * once per animation frame (~60fps) instead of on every input event.
+ */
+let pendingRange: [number, number] | null = null;
+let rafId = 0;
+
+export function setTimeRange(min: number, max: number) {
+	pendingRange = [min, max];
+	if (!rafId) {
+		rafId = requestAnimationFrame(() => {
+			rafId = 0;
+			if (pendingRange) {
+				timeRange.set(pendingRange);
+				pendingRange = null;
+			}
+		});
+	}
+}

--- a/frontend/src/lib/utils/uplotTouchZoom.ts
+++ b/frontend/src/lib/utils/uplotTouchZoom.ts
@@ -1,5 +1,6 @@
 /**
- * uPlot touch-zoom plugin — pinch-to-zoom and single-finger pan on the x-axis.
+ * uPlot touch-zoom plugin — pinch-to-zoom and single-finger pan on the x-axis,
+ * plus Shift+scroll to zoom and Shift+drag to pan on desktop.
  *
  * Adapted from the official uPlot zoom-touch demo by Leon Sorokin:
  * https://github.com/leeoniya/uPlot/blob/master/demos/zoom-touch.html
@@ -7,6 +8,7 @@
  * Changes from original:
  * - X-axis only (y-axis is left untouched)
  * - TypeScript types
+ * - Desktop: Shift+wheel zoom, Shift+drag pan
  * - Cleanup on destroy
  */
 
@@ -58,16 +60,14 @@ export function touchZoomPlugin(): uPlot.Plugin {
 			}
 		}
 
+		// --- Touch: pinch-to-zoom and single-finger pan ---
+
 		let rafPending = false;
 
 		function zoom() {
 			rafPending = false;
 
 			const left = to.x;
-
-			// For single-finger pan: d stays 1, so xFactor = 1 — only the
-			// position shift (leftPct difference) moves the viewport.
-			// For pinch: d changes, producing a zoom factor.
 			const xFactor = fr.d / to.d;
 			const leftPct = left / rect.width;
 
@@ -104,8 +104,105 @@ export function touchZoomPlugin(): uPlot.Plugin {
 		over.addEventListener('touchstart', touchstart, { passive: true });
 		over.addEventListener('touchend', touchend);
 
+		// --- Desktop: Shift+wheel to zoom ---
+
+		let wheelRafPending = false;
+		let wheelAccum = 0;
+		let wheelCursorPct = 0.5;
+
+		function applyWheelZoom() {
+			wheelRafPending = false;
+
+			const xRange = (u.scales.x.max ?? 0) - (u.scales.x.min ?? 0);
+			// Each ~100px of wheel delta = 20% zoom
+			const factor = Math.pow(1.2, wheelAccum / 100);
+			wheelAccum = 0;
+
+			const nxRange = xRange * factor;
+			const xMin = u.scales.x.min ?? 0;
+			// Keep the point under the cursor fixed
+			const nxMin = xMin + (xRange - nxRange) * wheelCursorPct;
+			const nxMax = nxMin + nxRange;
+
+			u.setScale('x', { min: nxMin, max: nxMax });
+		}
+
+		function onWheel(e: WheelEvent) {
+			if (!e.shiftKey) return;
+
+			e.preventDefault();
+
+			rect = over.getBoundingClientRect();
+			wheelCursorPct = (e.clientX - rect.left) / rect.width;
+			// macOS swaps deltaY to deltaX when Shift is held
+			const delta = Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY;
+			wheelAccum += delta;
+
+			if (!wheelRafPending) {
+				wheelRafPending = true;
+				requestAnimationFrame(applyWheelZoom);
+			}
+		}
+
+		over.addEventListener('wheel', onWheel, { passive: false });
+
+		// --- Desktop: Shift+drag to pan ---
+
+		let dragging = false;
+		let dragStartX = 0;
+		let dragOxMin = 0;
+		let dragOxMax = 0;
+		let dragRafPending = false;
+		let dragCurrentX = 0;
+
+		function applyDragPan() {
+			dragRafPending = false;
+
+			rect = over.getBoundingClientRect();
+			const dx = dragCurrentX - dragStartX;
+			const xRange = dragOxMax - dragOxMin;
+			const shift = -(dx / rect.width) * xRange;
+
+			u.setScale('x', { min: dragOxMin + shift, max: dragOxMax + shift });
+		}
+
+		function onMouseDown(e: MouseEvent) {
+			if (!e.shiftKey || e.button !== 0) return;
+
+			e.preventDefault();
+			// Suppress uPlot's built-in cursor drag while we're panning
+			over.style.pointerEvents = 'none';
+
+			dragging = true;
+			dragStartX = e.clientX;
+			dragOxMin = u.scales.x.min ?? 0;
+			dragOxMax = u.scales.x.max ?? 0;
+
+			document.addEventListener('mousemove', onMouseMove);
+			document.addEventListener('mouseup', onMouseUp);
+		}
+
+		function onMouseMove(e: MouseEvent) {
+			if (!dragging) return;
+
+			dragCurrentX = e.clientX;
+			if (!dragRafPending) {
+				dragRafPending = true;
+				requestAnimationFrame(applyDragPan);
+			}
+		}
+
+		function onMouseUp() {
+			dragging = false;
+			over.style.pointerEvents = '';
+			document.removeEventListener('mousemove', onMouseMove);
+			document.removeEventListener('mouseup', onMouseUp);
+		}
+
+		over.addEventListener('mousedown', onMouseDown);
+
 		// Store refs for cleanup
-		(u as any)._touchZoom = { touchstart, touchend };
+		(u as any)._touchZoom = { touchstart, touchend, onWheel, onMouseDown };
 	}
 
 	function destroy(u: uPlot) {
@@ -113,6 +210,8 @@ export function touchZoomPlugin(): uPlot.Plugin {
 		if (refs) {
 			u.over.removeEventListener('touchstart', refs.touchstart);
 			u.over.removeEventListener('touchend', refs.touchend);
+			u.over.removeEventListener('wheel', refs.onWheel);
+			u.over.removeEventListener('mousedown', refs.onMouseDown);
 		}
 	}
 


### PR DESCRIPTION
Profiling on both mobile (iPhone, Safari) and desktop (M3 Max, Chrome/Safari) showed CPU peaking at 400–650% during plot zoom/pan. The root cause is every visible plot redrawing synchronously on every input event via the shared `timeRange` store.

- Throttle `timeRange` store writes through `requestAnimationFrame` so multiple `setScale` calls within the same frame produce only one store update
- Use `IntersectionObserver` to skip `setScale` on off-screen plots entirely, applying the pending range when they scroll into view
- Add Shift+scroll to zoom and Shift+drag to pan on desktop, bringing parity with the mobile pinch-to-zoom and single-finger pan gestures