### PR TITLE
Plot tab polish: trajectory, spectrogram, params download, satellite map, flight date

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@duckdb/duckdb-wasm": "^1.33.1-dev20.0",
         "chart.js": "^4.5.1",
+        "fft.js": "^4.0.4",
         "mapbox-gl": "^3.20.0",
         "uplot": "^1.6.31"
       },
@@ -2583,6 +2584,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fft.js": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/fft.js/-/fft.js-4.0.4.tgz",
+      "integrity": "sha512-f9c00hphOgeQTlDyavwTtu6RiK8AIFjD6+jvXkNkpeQ7rirK3uFWVpalkoS4LAwbdX7mfZ8aoBfFVQX1Re/8aw==",
+      "license": "MIT"
     },
     "node_modules/find-replace": {
       "version": "3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@duckdb/duckdb-wasm": "^1.33.1-dev20.0",
     "chart.js": "^4.5.1",
+    "fft.js": "^4.0.4",
     "mapbox-gl": "^3.20.0",
     "uplot": "^1.6.31"
   },

--- a/frontend/src/lib/components/viewer/DragDropPlotList.svelte
+++ b/frontend/src/lib/components/viewer/DragDropPlotList.svelte
@@ -61,9 +61,10 @@
 	}
 </script>
 
-<div class="flex flex-col gap-4">
+<div role="list" class="flex flex-col gap-4">
 	{#each plots as plot, i (plot.id)}
 		<div
+			role="listitem"
 			class="relative transition-opacity duration-150"
 			class:opacity-50={dragFromIndex === i}
 			ondragover={handleDragOver(i)}

--- a/frontend/src/lib/components/viewer/DragDropPlotList.svelte
+++ b/frontend/src/lib/components/viewer/DragDropPlotList.svelte
@@ -3,6 +3,7 @@
 	import { reorderPlots } from '$lib/stores/logViewer';
 	import PlotStrip from './PlotStrip.svelte';
 	import TrajectoryPlot from './TrajectoryPlot.svelte';
+	import SpectrogramPlot from './SpectrogramPlot.svelte';
 	import LazyPlot from './LazyPlot.svelte';
 
 	let { plots, logId, metadata } = $props<{
@@ -78,6 +79,18 @@
 			<LazyPlot>
 				{#if plot.kind === 'xy'}
 					<TrajectoryPlot
+						config={plot}
+						{logId}
+						{metadata}
+						index={i}
+						totalCount={plots.length}
+						onMoveUp={() => moveUp(i)}
+						onMoveDown={() => moveDown(i)}
+						onDragStart={handleDragStart(i)}
+						onDragEnd={handleDragEnd}
+					/>
+				{:else if plot.kind === 'spectrogram'}
+					<SpectrogramPlot
 						config={plot}
 						{logId}
 						{metadata}

--- a/frontend/src/lib/components/viewer/DragDropPlotList.svelte
+++ b/frontend/src/lib/components/viewer/DragDropPlotList.svelte
@@ -2,6 +2,7 @@
 	import type { PlotConfig, FlightMetadata } from '$lib/types';
 	import { reorderPlots } from '$lib/stores/logViewer';
 	import PlotStrip from './PlotStrip.svelte';
+	import TrajectoryPlot from './TrajectoryPlot.svelte';
 	import LazyPlot from './LazyPlot.svelte';
 
 	let { plots, logId, metadata } = $props<{
@@ -75,17 +76,31 @@
 				<div class="absolute -top-px left-0 right-0 h-0.5 bg-blue-500 z-10 rounded-full"></div>
 			{/if}
 			<LazyPlot>
-				<PlotStrip
-					config={plot}
-					{logId}
-					{metadata}
-					index={i}
-					totalCount={plots.length}
-					onMoveUp={() => moveUp(i)}
-					onMoveDown={() => moveDown(i)}
-					onDragStart={handleDragStart(i)}
-					onDragEnd={handleDragEnd}
-				/>
+				{#if plot.kind === 'xy'}
+					<TrajectoryPlot
+						config={plot}
+						{logId}
+						{metadata}
+						index={i}
+						totalCount={plots.length}
+						onMoveUp={() => moveUp(i)}
+						onMoveDown={() => moveDown(i)}
+						onDragStart={handleDragStart(i)}
+						onDragEnd={handleDragEnd}
+					/>
+				{:else}
+					<PlotStrip
+						config={plot}
+						{logId}
+						{metadata}
+						index={i}
+						totalCount={plots.length}
+						onMoveUp={() => moveUp(i)}
+						onMoveDown={() => moveDown(i)}
+						onDragStart={handleDragStart(i)}
+						onDragEnd={handleDragEnd}
+					/>
+				{/if}
 			</LazyPlot>
 		</div>
 	{/each}

--- a/frontend/src/lib/components/viewer/FlightSummaryHeader.svelte
+++ b/frontend/src/lib/components/viewer/FlightSummaryHeader.svelte
@@ -1,9 +1,23 @@
 <script lang="ts">
 	import type { FlightMetadata } from '$lib/types';
-	import { formatDuration } from '$lib/utils/formatters';
+	import { formatDuration, parseFlightDateFromFilename, formatFlightDateTime } from '$lib/utils/formatters';
 	import { getHardwareName } from '$lib/utils/hardwareNames';
 
-	let { metadata, logId, vehicleType, locationName } = $props<{ metadata: FlightMetadata; logId: string; vehicleType?: string | null; locationName?: string | null }>();
+	let { metadata, logId, vehicleType, locationName, filename, createdAt } = $props<{ metadata: FlightMetadata; logId: string; vehicleType?: string | null; locationName?: string | null; filename?: string | null; createdAt?: string | null }>();
+
+	// Flight date: prefer filename (PX4 encodes flight time), fall back to upload time.
+	const flightDate = $derived.by(() => {
+		const fromName = parseFlightDateFromFilename(filename);
+		if (fromName) return { date: fromName, source: 'flight' as const };
+		if (createdAt) {
+			const d = new Date(createdAt);
+			if (!isNaN(d.getTime())) return { date: d, source: 'upload' as const };
+		}
+		return null;
+	});
+	const flightDateParts = $derived(flightDate ? formatFlightDateTime(flightDate.date) : null);
+	const flightDateLabel = $derived(flightDate?.source === 'upload' ? 'Uploaded' : 'Flight Date');
+	const flightDateTooltip = $derived(flightDate ? flightDate.date.toLocaleString() : '');
 
 	// Parse location_name: "City, Country [CC]" → { city, country, countryCode, flag }
 	const location = $derived.by(() => {
@@ -91,6 +105,12 @@
 				<dd class="text-xs text-gray-400 whitespace-nowrap">No Location</dd>
 			{/if}
 		</div>
+		{#if flightDateParts}
+			<div class="shrink-0 px-3 py-1.5" title={flightDateTooltip}>
+				<dt class="text-[10px] text-gray-500">{flightDateLabel}</dt>
+				<dd class="text-xs font-medium text-gray-700 whitespace-nowrap">{flightDateParts.date} <span class="text-gray-500">{flightDateParts.time}</span></dd>
+			</div>
+		{/if}
 		<div class="shrink-0 px-3 py-1.5">
 			<dt class="text-[10px] text-gray-500">Hardware</dt>
 			<dd class="text-xs font-medium text-gray-700 whitespace-nowrap">{getHardwareName(metadata.ver_hw)}</dd>
@@ -163,6 +183,12 @@
 				<dd class="text-sm text-gray-400 whitespace-nowrap">No Location</dd>
 			{/if}
 		</div>
+		{#if flightDateParts}
+			<div class="px-2 lg:px-4 py-2 lg:py-3" title={flightDateTooltip}>
+				<dt class="text-xs text-gray-500">{flightDateLabel}</dt>
+				<dd class="text-sm font-medium text-gray-700 mt-0.5 whitespace-nowrap">{flightDateParts.date} <span class="text-gray-500">{flightDateParts.time}</span></dd>
+			</div>
+		{/if}
 		<div class="px-2 lg:px-4 py-2 lg:py-3">
 			<dt class="text-xs text-gray-500">Hardware</dt>
 			<dd class="text-sm font-medium text-gray-700 mt-0.5 truncate" title={metadata.ver_hw ?? ''}>{getHardwareName(metadata.ver_hw)}</dd>

--- a/frontend/src/lib/components/viewer/MapPanel.svelte
+++ b/frontend/src/lib/components/viewer/MapPanel.svelte
@@ -104,7 +104,7 @@
 			const initialBounds = getBounds();
 			map = new mb.Map({
 				container: mapContainer,
-				style: 'mapbox://styles/mapbox/outdoors-v12',
+				style: 'mapbox://styles/mapbox/satellite-streets-v12',
 				attributionControl: true,
 				...(initialBounds ? { bounds: initialBounds, fitBoundsOptions: { padding: 100, maxZoom: 16 } } : {}),
 			});

--- a/frontend/src/lib/components/viewer/ParamDiffPanel.svelte
+++ b/frontend/src/lib/components/viewer/ParamDiffPanel.svelte
@@ -17,7 +17,7 @@
 	type SortKey = 'name' | 'value' | 'default' | 'delta';
 	type SortDir = 'asc' | 'desc';
 
-	let viewMode = $state<ViewMode>(diffs.length > 0 ? 'non-default' : 'all');
+	let viewMode = $state<ViewMode>('non-default');
 	let sortKey = $state<SortKey>('name');
 	let sortDir = $state<SortDir>('asc');
 	let searchText = $state('');

--- a/frontend/src/lib/components/viewer/SpectrogramPlot.svelte
+++ b/frontend/src/lib/components/viewer/SpectrogramPlot.svelte
@@ -1,0 +1,434 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import type { PlotConfig, FlightMetadata } from '$lib/types';
+	import { activePlots, togglePlotMinimized } from '$lib/stores/logViewer';
+	import { initDuckDB, LogSession } from '$lib/utils/duckdb';
+	import { computePsdSpectrogram, sumPsd, psdToDb, type SpectrogramResult } from '$lib/utils/spectrogram';
+	import { viridis } from '$lib/utils/viridis';
+
+	let { config, logId, metadata, index, totalCount, onMoveUp, onMoveDown, onDragStart, onDragEnd } = $props<{
+		config: PlotConfig;
+		logId: string;
+		metadata: FlightMetadata;
+		index?: number;
+		totalCount?: number;
+		onMoveUp?: () => void;
+		onMoveDown?: () => void;
+		onDragStart?: (e: DragEvent) => void;
+		onDragEnd?: (e: DragEvent) => void;
+	}>();
+
+	const sessionCache = (globalThis as any).__plotSessionCache ??= new Map<string, LogSession>();
+
+	let containerEl: HTMLDivElement | undefined = $state();
+	let canvasEl: HTMLCanvasElement | undefined = $state();
+	let resizeObserver: ResizeObserver | null = null;
+
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let plotHeight = $state(300);
+	let lastWidth = 0;
+
+	// Computed once on data load, re-rendered on resize
+	let spec: SpectrogramResult | null = null;
+	let dbMin = 0;
+	let dbMax = 0;
+	let xRangeStart = 0; // seconds offset (relative to log start)
+
+	async function getSession(): Promise<LogSession> {
+		if (sessionCache.has(logId)) return sessionCache.get(logId)!;
+		const db = await initDuckDB();
+		const session = new LogSession(db, logId);
+		sessionCache.set(logId, session);
+		return session;
+	}
+
+	function removePlot() {
+		activePlots.update((plots) => plots.filter((p) => p.id !== config.id));
+	}
+
+	function downloadPng() {
+		if (!canvasEl) return;
+		const link = document.createElement('a');
+		link.download = `spectrogram.png`;
+		link.href = canvasEl.toDataURL('image/png');
+		link.click();
+	}
+
+	async function loadAndRender() {
+		loading = true;
+		error = null;
+
+		try {
+			const session = await getSession();
+			const topics = new Set(Object.keys(metadata.topics));
+			if (!topics.has('sensor_combined')) {
+				removePlot();
+				return;
+			}
+
+			const fields = ['accelerometer_m_s2[0]', 'accelerometer_m_s2[1]', 'accelerometer_m_s2[2]'];
+			const r = await session.queryTopic('sensor_combined', fields);
+			if (!r || r.timestamps.length < 256) {
+				removePlot();
+				return;
+			}
+
+			// Sampling frequency: total span / number of samples (matches v1).
+			const ts = r.timestamps;
+			const totalSpan = ts[ts.length - 1] - ts[0]; // seconds
+			if (totalSpan <= 0) {
+				removePlot();
+				return;
+			}
+			const fs = ts.length / totalSpan;
+			if (fs < 100) {
+				// v1 also drops the plot below 100 Hz
+				removePlot();
+				return;
+			}
+
+			// Compute per-axis spectrograms then sum the PSDs.
+			const specs = r.series
+				.map((s) => computePsdSpectrogram(s, fs, 256, 128))
+				.filter((s): s is SpectrogramResult => s != null);
+			if (specs.length === 0) {
+				removePlot();
+				return;
+			}
+			const summed = sumPsd(specs);
+			if (!summed) {
+				removePlot();
+				return;
+			}
+			const range = psdToDb(summed.psd);
+			spec = summed;
+			dbMin = range.min;
+			dbMax = range.max;
+			xRangeStart = ts[0];
+
+			loading = false;
+			const tryRender = () => {
+				const w = containerEl?.getBoundingClientRect().width ?? 0;
+				if (w > 0) {
+					render(w);
+				} else {
+					requestAnimationFrame(tryRender);
+				}
+			};
+			requestAnimationFrame(tryRender);
+		} catch (e) {
+			console.error('SpectrogramPlot load error:', e);
+			error = e instanceof Error ? e.message : 'Failed to load spectrogram data';
+			loading = false;
+		}
+	}
+
+	function niceTicks(min: number, max: number, target: number): number[] {
+		const range = max - min;
+		if (range <= 0) return [min];
+		const rough = range / target;
+		const pow = Math.pow(10, Math.floor(Math.log10(rough)));
+		const norm = rough / pow;
+		let step;
+		if (norm < 1.5) step = pow;
+		else if (norm < 3) step = 2 * pow;
+		else if (norm < 7) step = 5 * pow;
+		else step = 10 * pow;
+		const start = Math.ceil(min / step) * step;
+		const ticks: number[] = [];
+		for (let v = start; v <= max + step * 0.5; v += step) {
+			ticks.push(Math.round(v / step) * step);
+		}
+		return ticks;
+	}
+
+	function formatTimeTick(seconds: number): string {
+		if (seconds < 60) return `${seconds.toFixed(0)}s`;
+		const m = Math.floor(seconds / 60);
+		const s = Math.floor(seconds % 60);
+		return `${m}:${s.toString().padStart(2, '0')}`;
+	}
+
+	function render(widthOverride?: number) {
+		const canvas = canvasEl;
+		if (!canvas || !containerEl || !spec) return;
+
+		const dpr = window.devicePixelRatio || 1;
+		const cssW = widthOverride ?? lastWidth ?? containerEl.getBoundingClientRect().width;
+		if (!cssW || cssW <= 0) return;
+		lastWidth = cssW;
+		const cssH = plotHeight;
+
+		canvas.style.width = `${cssW}px`;
+		canvas.style.height = `${cssH}px`;
+		canvas.width = Math.floor(cssW * dpr);
+		canvas.height = Math.floor(cssH * dpr);
+
+		const ctx = canvas.getContext('2d');
+		if (!ctx) return;
+		ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+		ctx.clearRect(0, 0, cssW, cssH);
+
+		// Layout: padding for axes labels and the color bar on the right.
+		const padL = 56, padR = 78, padT = 12, padB = 32;
+		const plotW = cssW - padL - padR;
+		const plotH = cssH - padT - padB;
+		if (plotW <= 0 || plotH <= 0) return;
+
+		const { freqs, times, psd, nFreq, nTime } = spec;
+		const fMin = freqs[0];
+		const fMax = freqs[nFreq - 1];
+		const tMin = times[0];
+		const tMax = times[nTime - 1];
+
+		// Render the heatmap into an offscreen ImageData sized to the plot area
+		// (in CSS pixels, which we then upscale via dpr).
+		const imgW = Math.max(1, Math.floor(plotW));
+		const imgH = Math.max(1, Math.floor(plotH));
+		const img = ctx.createImageData(imgW, imgH);
+		const dbRange = dbMax - dbMin || 1;
+
+		for (let py = 0; py < imgH; py++) {
+			// pixel y=0 is top → highest frequency
+			const fNorm = 1 - py / (imgH - 1 || 1);
+			const fIdxF = fNorm * (nFreq - 1);
+			const fIdx = Math.min(nFreq - 1, Math.max(0, Math.round(fIdxF)));
+			for (let px = 0; px < imgW; px++) {
+				const tNorm = px / (imgW - 1 || 1);
+				const tIdxF = tNorm * (nTime - 1);
+				const tIdx = Math.min(nTime - 1, Math.max(0, Math.round(tIdxF)));
+				const v = psd[fIdx * nTime + tIdx];
+				const norm = (v - dbMin) / dbRange;
+				const [r, g, b] = viridis(norm);
+				const off = (py * imgW + px) * 4;
+				img.data[off] = r;
+				img.data[off + 1] = g;
+				img.data[off + 2] = b;
+				img.data[off + 3] = 255;
+			}
+		}
+
+		// Draw heatmap to a temporary canvas at native imgW×imgH, then drawImage
+		// stretched to the plot area (so dpr scaling works correctly).
+		const tmp = document.createElement('canvas');
+		tmp.width = imgW;
+		tmp.height = imgH;
+		const tmpCtx = tmp.getContext('2d');
+		if (tmpCtx) {
+			tmpCtx.putImageData(img, 0, 0);
+			ctx.imageSmoothingEnabled = false;
+			ctx.drawImage(tmp, padL, padT, plotW, plotH);
+		}
+
+		// --- Border ---
+		ctx.strokeStyle = '#d1d5db';
+		ctx.lineWidth = 1;
+		ctx.strokeRect(padL, padT, plotW, plotH);
+
+		// --- Axes (ticks + labels) ---
+		ctx.fillStyle = '#9ca3af';
+		ctx.font = '11px ui-sans-serif, system-ui, sans-serif';
+		ctx.strokeStyle = '#9ca3af';
+
+		// Frequency ticks (Y axis, left side)
+		const fTicks = niceTicks(fMin, fMax, Math.max(4, Math.floor(plotH / 50)));
+		ctx.textAlign = 'right';
+		ctx.textBaseline = 'middle';
+		for (const t of fTicks) {
+			if (t < fMin || t > fMax) continue;
+			const norm = (t - fMin) / (fMax - fMin);
+			const y = padT + plotH - norm * plotH;
+			ctx.beginPath();
+			ctx.moveTo(padL - 3, y);
+			ctx.lineTo(padL, y);
+			ctx.stroke();
+			ctx.fillText(t.toFixed(0), padL - 6, y);
+		}
+
+		// Time ticks (X axis, bottom)
+		const xTicks = niceTicks(tMin, tMax, Math.max(4, Math.floor(plotW / 80)));
+		ctx.textAlign = 'center';
+		ctx.textBaseline = 'top';
+		for (const t of xTicks) {
+			if (t < tMin || t > tMax) continue;
+			const norm = (t - tMin) / (tMax - tMin);
+			const x = padL + norm * plotW;
+			ctx.beginPath();
+			ctx.moveTo(x, padT + plotH);
+			ctx.lineTo(x, padT + plotH + 3);
+			ctx.stroke();
+			ctx.fillText(formatTimeTick(t), x, padT + plotH + 6);
+		}
+
+		// Axis labels
+		ctx.save();
+		ctx.translate(14, padT + plotH / 2);
+		ctx.rotate(-Math.PI / 2);
+		ctx.textAlign = 'center';
+		ctx.textBaseline = 'alphabetic';
+		ctx.fillText('[Hz]', 0, 0);
+		ctx.restore();
+
+		// --- Color bar (right side) ---
+		const cbX = cssW - padR + 18;
+		const cbW = 12;
+		const cbY = padT;
+		const cbH = plotH;
+
+		// Build colorbar gradient as ImageData (top = max, bottom = min)
+		const cbImg = ctx.createImageData(cbW, cbH);
+		for (let py = 0; py < cbH; py++) {
+			const norm = 1 - py / (cbH - 1 || 1);
+			const [r, g, b] = viridis(norm);
+			for (let px = 0; px < cbW; px++) {
+				const off = (py * cbW + px) * 4;
+				cbImg.data[off] = r;
+				cbImg.data[off + 1] = g;
+				cbImg.data[off + 2] = b;
+				cbImg.data[off + 3] = 255;
+			}
+		}
+		const cbTmp = document.createElement('canvas');
+		cbTmp.width = cbW;
+		cbTmp.height = cbH;
+		const cbTmpCtx = cbTmp.getContext('2d');
+		if (cbTmpCtx) {
+			cbTmpCtx.putImageData(cbImg, 0, 0);
+			ctx.drawImage(cbTmp, cbX, cbY);
+		}
+		ctx.strokeRect(cbX, cbY, cbW, cbH);
+
+		// Color bar tick labels
+		const cbTicks = niceTicks(dbMin, dbMax, 5);
+		ctx.textAlign = 'left';
+		ctx.textBaseline = 'middle';
+		for (const t of cbTicks) {
+			if (t < dbMin || t > dbMax) continue;
+			const norm = (t - dbMin) / (dbMax - dbMin || 1);
+			const y = cbY + cbH - norm * cbH;
+			ctx.beginPath();
+			ctx.moveTo(cbX + cbW, y);
+			ctx.lineTo(cbX + cbW + 3, y);
+			ctx.stroke();
+			ctx.fillText(t.toFixed(0), cbX + cbW + 6, y);
+		}
+		ctx.textAlign = 'center';
+		ctx.fillText('[dB]', cbX + cbW / 2, cbY + cbH + 14);
+	}
+
+	onMount(() => {
+		if (containerEl) {
+			resizeObserver = new ResizeObserver((entries) => {
+				for (const entry of entries) {
+					const w = entry.contentRect.width;
+					if (w > 0) {
+						plotHeight = w < 640 ? 220 : 300;
+						render(w);
+					}
+				}
+			});
+			resizeObserver.observe(containerEl);
+		}
+		loadAndRender();
+	});
+
+	onDestroy(() => {
+		if (resizeObserver) {
+			resizeObserver.disconnect();
+			resizeObserver = null;
+		}
+	});
+</script>
+
+<div class="rounded-lg ring-1 ring-gray-200 bg-white overflow-hidden" bind:this={containerEl}>
+	<div class="flex items-center justify-between px-2 sm:px-4 py-2 sm:py-2.5 border-b border-gray-100">
+		<div class="flex flex-wrap items-center gap-2 sm:gap-4">
+			{#if onDragStart}
+				<div
+					class="hidden md:flex items-center cursor-grab active:cursor-grabbing text-gray-300 hover:text-gray-500"
+					draggable="true"
+					ondragstart={onDragStart}
+					ondragend={onDragEnd}
+					role="button"
+					tabindex="0"
+					aria-label="Drag to reorder"
+				>
+					<svg class="size-5" viewBox="0 0 20 20" fill="currentColor">
+						<circle cx="7" cy="4" r="1.5" /><circle cx="13" cy="4" r="1.5" />
+						<circle cx="7" cy="10" r="1.5" /><circle cx="13" cy="10" r="1.5" />
+						<circle cx="7" cy="16" r="1.5" /><circle cx="13" cy="16" r="1.5" />
+					</svg>
+				</div>
+				<div class="flex md:hidden flex-col -space-y-0.5">
+					<button
+						class="text-gray-400 hover:text-gray-600 disabled:opacity-30 disabled:cursor-default"
+						onclick={onMoveUp}
+						disabled={index === 0}
+						aria-label="Move plot up"
+					>
+						<svg class="size-3.5" viewBox="0 0 20 20" fill="currentColor">
+							<path fill-rule="evenodd" d="M10 3.293l-6.354 6.353a1 1 0 001.415 1.414L10 6.121l4.939 4.939a1 1 0 001.414-1.414L10 3.293z" clip-rule="evenodd" />
+						</svg>
+					</button>
+					<button
+						class="text-gray-400 hover:text-gray-600 disabled:opacity-30 disabled:cursor-default"
+						onclick={onMoveDown}
+						disabled={index === (totalCount ?? 1) - 1}
+						aria-label="Move plot down"
+					>
+						<svg class="size-3.5" viewBox="0 0 20 20" fill="currentColor">
+							<path fill-rule="evenodd" d="M10 16.707l6.354-6.353a1 1 0 00-1.415-1.414L10 13.879l-4.939-4.939a1 1 0 00-1.414 1.414L10 16.707z" clip-rule="evenodd" />
+						</svg>
+					</button>
+				</div>
+			{/if}
+			<span class="text-xs sm:text-sm font-medium text-gray-900">{config.yLabel || 'Acceleration Power Spectral Density'}</span>
+		</div>
+		<div class="flex items-center gap-1">
+			<button class="text-gray-400 hover:text-gray-600" onclick={downloadPng} aria-label="Download as PNG">
+				<svg class="size-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+					<path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12M12 16.5V3" />
+				</svg>
+			</button>
+			<button class="text-gray-400 hover:text-gray-600" onclick={() => togglePlotMinimized(config.id)} aria-label={config.minimized ? 'Expand plot' : 'Minimize plot'}>
+				<svg class="size-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+					{#if config.minimized}
+						<path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+					{:else}
+						<path stroke-linecap="round" stroke-linejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
+					{/if}
+				</svg>
+			</button>
+			<button class="text-gray-400 hover:text-gray-600" onclick={removePlot} aria-label="Remove plot">
+				<svg class="size-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+					<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+				</svg>
+			</button>
+		</div>
+	</div>
+	<div
+		class="relative bg-gray-50 transition-all duration-200 ease-in-out"
+		style="min-height: {config.minimized ? 0 : plotHeight}px; max-height: {config.minimized ? '0px' : 'none'}; overflow: {config.minimized ? 'hidden' : 'visible'};"
+	>
+		{#if loading}
+			<div class="absolute inset-0 flex items-center justify-center">
+				<svg class="size-6 animate-spin text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+					<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+					<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+				</svg>
+				<span class="ml-2 text-sm text-gray-400">Computing FFT...</span>
+			</div>
+		{:else if error}
+			<div class="absolute inset-0 flex items-center justify-center">
+				<div class="text-center">
+					<svg class="size-8 text-red-300 mx-auto mb-2" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+					</svg>
+					<p class="text-sm text-red-500">{error}</p>
+				</div>
+			</div>
+		{/if}
+		<canvas bind:this={canvasEl} class="block w-full"></canvas>
+	</div>
+</div>

--- a/frontend/src/lib/components/viewer/TrajectoryPlot.svelte
+++ b/frontend/src/lib/components/viewer/TrajectoryPlot.svelte
@@ -1,0 +1,574 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import type { PlotConfig, FlightMetadata } from '$lib/types';
+	import { activePlots, togglePlotMinimized } from '$lib/stores/logViewer';
+	import { initDuckDB, LogSession } from '$lib/utils/duckdb';
+
+	let { config, logId, metadata, index, totalCount, onMoveUp, onMoveDown, onDragStart, onDragEnd } = $props<{
+		config: PlotConfig;
+		logId: string;
+		metadata: FlightMetadata;
+		index?: number;
+		totalCount?: number;
+		onMoveUp?: () => void;
+		onMoveDown?: () => void;
+		onDragStart?: (e: DragEvent) => void;
+		onDragEnd?: (e: DragEvent) => void;
+	}>();
+
+	const sessionCache = (globalThis as any).__plotSessionCache ??= new Map<string, LogSession>();
+
+	let containerEl: HTMLDivElement | undefined = $state();
+	let canvasEl: HTMLCanvasElement | undefined = $state();
+	let resizeObserver: ResizeObserver | null = null;
+
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let plotHeight = $state(460);
+	let lastWidth = 0;
+
+	// Cached series data (raw, in north/east meters). Re-rendered on resize.
+	type Series = { east: number[]; north: number[] };
+	let estSeries: Series | null = null;
+	let spSeries: Series | null = null;
+	let gpsSeries: Series | null = null;
+	let markerSeries: Series | null = null;
+
+	const COLOR_ESTIMATED = '#f97316'; // orange
+	const COLOR_SETPOINT = '#10b981'; // emerald
+	const COLOR_GPS = '#3b82f6'; // blue
+	const COLOR_SP_MARKER = '#ec4899'; // pink
+
+	const LEGEND = [
+		{ label: 'Estimated', color: COLOR_ESTIMATED },
+		{ label: 'Setpoint', color: COLOR_SETPOINT },
+		{ label: 'GPS (projected)', color: COLOR_GPS },
+		{ label: 'Position Setpoints', color: COLOR_SP_MARKER, marker: true },
+	];
+
+	async function getSession(): Promise<LogSession> {
+		if (sessionCache.has(logId)) return sessionCache.get(logId)!;
+		const db = await initDuckDB();
+		const session = new LogSession(db, logId);
+		sessionCache.set(logId, session);
+		return session;
+	}
+
+	function removePlot() {
+		activePlots.update((plots) => plots.filter((p) => p.id !== config.id));
+	}
+
+	function downloadPng() {
+		if (!canvasEl) return;
+		const link = document.createElement('a');
+		link.download = `trajectory.png`;
+		link.href = canvasEl.toDataURL('image/png');
+		link.click();
+	}
+
+	/**
+	 * Project lat/lon (degrees) to local NE meters using an equirectangular
+	 * projection around a reference latitude. Returns [north_m, east_m] in the
+	 * PX4 NED convention so it lines up with vehicle_local_position (x=N, y=E).
+	 */
+	function projectLatLon(
+		lat: number, lon: number, refLat: number, refLon: number
+	): [number, number] {
+		const R = 6378137; // WGS-84 equatorial radius
+		const refLatRad = (refLat * Math.PI) / 180;
+		const dLat = ((lat - refLat) * Math.PI) / 180;
+		const dLon = ((lon - refLon) * Math.PI) / 180;
+		const north = dLat * R;
+		const east = dLon * R * Math.cos(refLatRad);
+		return [north, east];
+	}
+
+	/**
+	 * Compute the bounding box of all visible series, with equal aspect (so the
+	 * trajectory isn't distorted) and a small margin.
+	 */
+	function computeBounds(): { eMin: number; eMax: number; nMin: number; nMax: number } | null {
+		let eMin = Infinity, eMax = -Infinity, nMin = Infinity, nMax = -Infinity;
+		const all = [estSeries, spSeries, gpsSeries, markerSeries].filter((s): s is Series => !!s);
+		if (all.length === 0) return null;
+		for (const s of all) {
+			for (let i = 0; i < s.east.length; i++) {
+				const e = s.east[i], n = s.north[i];
+				if (!Number.isFinite(e) || !Number.isFinite(n)) continue;
+				if (e < eMin) eMin = e;
+				if (e > eMax) eMax = e;
+				if (n < nMin) nMin = n;
+				if (n > nMax) nMax = n;
+			}
+		}
+		if (!Number.isFinite(eMin)) return null;
+		// Add 5% margin and equalize aspect so the shape isn't distorted.
+		const eRange = eMax - eMin || 1;
+		const nRange = nMax - nMin || 1;
+		const margin = 0.05;
+		eMin -= eRange * margin; eMax += eRange * margin;
+		nMin -= nRange * margin; nMax += nRange * margin;
+		return { eMin, eMax, nMin, nMax };
+	}
+
+	/** Pick "nice" tick values for an axis range. */
+	function niceTicks(min: number, max: number, target: number): number[] {
+		const range = max - min;
+		if (range <= 0) return [min];
+		const rough = range / target;
+		const pow = Math.pow(10, Math.floor(Math.log10(rough)));
+		const norm = rough / pow;
+		let step;
+		if (norm < 1.5) step = pow;
+		else if (norm < 3) step = 2 * pow;
+		else if (norm < 7) step = 5 * pow;
+		else step = 10 * pow;
+		const start = Math.ceil(min / step) * step;
+		const ticks: number[] = [];
+		for (let v = start; v <= max + step * 0.5; v += step) {
+			ticks.push(Math.round(v / step) * step);
+		}
+		return ticks;
+	}
+
+	function render(widthOverride?: number) {
+		const canvas = canvasEl;
+		if (!canvas || !containerEl) return;
+		const bounds = computeBounds();
+		if (!bounds) return;
+
+		const dpr = window.devicePixelRatio || 1;
+		const cssW = widthOverride ?? lastWidth ?? containerEl.getBoundingClientRect().width;
+		if (!cssW || cssW <= 0) return;
+		lastWidth = cssW;
+		const cssH = plotHeight;
+
+		canvas.style.width = `${cssW}px`;
+		canvas.style.height = `${cssH}px`;
+		canvas.width = Math.floor(cssW * dpr);
+		canvas.height = Math.floor(cssH * dpr);
+
+		const ctx = canvas.getContext('2d');
+		if (!ctx) return;
+		ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+		ctx.clearRect(0, 0, cssW, cssH);
+
+		// Layout: padding for axes labels.
+		const padL = 56, padR = 16, padT = 12, padB = 36;
+		const plotW = cssW - padL - padR;
+		const plotH = cssH - padT - padB;
+		if (plotW <= 0 || plotH <= 0) return;
+
+		// Fill the plot area on both axes (independent X/Y scaling). Aspect is
+		// not preserved — the trajectory shape stretches to fit, like the other
+		// time-series plots on the page.
+		let { eMin, eMax, nMin, nMax } = bounds;
+		const dataE = eMax - eMin || 1;
+		const dataN = nMax - nMin || 1;
+		const scaleX = plotW / dataE;
+		const scaleY = plotH / dataN;
+		const offsetX = padL;
+		const offsetY = padT;
+		const drawW = plotW;
+		const drawH = plotH;
+
+		const toPx = (e: number, n: number): [number, number] => {
+			const x = offsetX + (e - eMin) * scaleX;
+			// Y is inverted: north up means smaller pixel y.
+			const y = offsetY + (nMax - n) * scaleY;
+			return [x, y];
+		};
+
+		// --- Grid + axes ---
+		ctx.strokeStyle = '#e5e7eb';
+		ctx.lineWidth = 1;
+		ctx.fillStyle = '#9ca3af';
+		ctx.font = '11px ui-sans-serif, system-ui, sans-serif';
+
+		const eTicks = niceTicks(eMin, eMax, Math.max(4, Math.floor(plotW / 80)));
+		const nTicks = niceTicks(nMin, nMax, Math.max(4, Math.floor(plotH / 50)));
+
+		ctx.beginPath();
+		for (const t of eTicks) {
+			const [x] = toPx(t, 0);
+			if (x < offsetX - 0.5 || x > offsetX + drawW + 0.5) continue;
+			ctx.moveTo(x, offsetY);
+			ctx.lineTo(x, offsetY + drawH);
+		}
+		for (const t of nTicks) {
+			const [, y] = toPx(0, t);
+			if (y < offsetY - 0.5 || y > offsetY + drawH + 0.5) continue;
+			ctx.moveTo(offsetX, y);
+			ctx.lineTo(offsetX + drawW, y);
+		}
+		ctx.stroke();
+
+		// Tick labels
+		ctx.textAlign = 'center';
+		ctx.textBaseline = 'top';
+		for (const t of eTicks) {
+			const [x] = toPx(t, 0);
+			if (x < offsetX - 0.5 || x > offsetX + drawW + 0.5) continue;
+			ctx.fillText(String(Math.round(t)), x, offsetY + drawH + 4);
+		}
+		ctx.textAlign = 'right';
+		ctx.textBaseline = 'middle';
+		for (const t of nTicks) {
+			const [, y] = toPx(0, t);
+			if (y < offsetY - 0.5 || y > offsetY + drawH + 0.5) continue;
+			ctx.fillText(String(Math.round(t)), offsetX - 6, y);
+		}
+
+		// Axis labels
+		ctx.textAlign = 'center';
+		ctx.textBaseline = 'alphabetic';
+		ctx.fillText('East [m]', offsetX + drawW / 2, cssH - 6);
+		ctx.save();
+		ctx.translate(14, offsetY + drawH / 2);
+		ctx.rotate(-Math.PI / 2);
+		ctx.fillText('North [m]', 0, 0);
+		ctx.restore();
+
+		// Border
+		ctx.strokeStyle = '#d1d5db';
+		ctx.strokeRect(offsetX, offsetY, drawW, drawH);
+
+		// --- Polylines ---
+		const drawLine = (s: Series | null, color: string, width: number) => {
+			if (!s || s.east.length < 2) return;
+			ctx.strokeStyle = color;
+			ctx.lineWidth = width;
+			ctx.lineJoin = 'round';
+			ctx.lineCap = 'round';
+			ctx.beginPath();
+			let started = false;
+			for (let i = 0; i < s.east.length; i++) {
+				const e = s.east[i], n = s.north[i];
+				if (!Number.isFinite(e) || !Number.isFinite(n)) { started = false; continue; }
+				const [x, y] = toPx(e, n);
+				if (!started) { ctx.moveTo(x, y); started = true; }
+				else ctx.lineTo(x, y);
+			}
+			ctx.stroke();
+		};
+
+		drawLine(gpsSeries, COLOR_GPS, 1.5);
+		drawLine(estSeries, COLOR_ESTIMATED, 1.75);
+		drawLine(spSeries, COLOR_SETPOINT, 1.75);
+
+		// --- Marker rings ---
+		if (markerSeries) {
+			ctx.strokeStyle = COLOR_SP_MARKER;
+			ctx.lineWidth = 2;
+			for (let i = 0; i < markerSeries.east.length; i++) {
+				const e = markerSeries.east[i], n = markerSeries.north[i];
+				if (!Number.isFinite(e) || !Number.isFinite(n)) continue;
+				const [x, y] = toPx(e, n);
+				ctx.beginPath();
+				ctx.arc(x, y, 5, 0, Math.PI * 2);
+				ctx.stroke();
+			}
+		}
+	}
+
+	async function loadAndRender() {
+		loading = true;
+		error = null;
+
+		try {
+			const session = await getSession();
+			const topics = new Set(Object.keys(metadata.topics));
+
+			// --- Estimated trajectory (vehicle_local_position) ---
+			let estX: Float64Array | null = null;
+			let estY: Float64Array | null = null;
+			let refLat: number | null = null;
+			let refLon: number | null = null;
+			if (topics.has('vehicle_local_position')) {
+				const lpSchema = await session.getTopicSchema('vehicle_local_position');
+				const lpNames = new Set(lpSchema.map((c) => c.name));
+				const hasRef = lpNames.has('ref_lat') && lpNames.has('ref_lon');
+				const fields = hasRef ? ['x', 'y', 'ref_lat', 'ref_lon'] : ['x', 'y'];
+				const r = await session.queryTopic('vehicle_local_position', fields);
+				if (r) {
+					estX = r.series[0];
+					estY = r.series[1];
+					if (hasRef) {
+						// Use the first non-zero ref_lat/lon as the projection origin.
+						for (let i = 0; i < r.series[2].length; i++) {
+							if (r.series[2][i] !== 0 && r.series[3][i] !== 0) {
+								refLat = r.series[2][i];
+								refLon = r.series[3][i];
+								break;
+							}
+						}
+					}
+				}
+			}
+
+			// Fallback projection origin: first valid GPS fix from metadata.
+			if ((refLat == null || refLon == null) && metadata.analysis?.gps_track?.length) {
+				const first = metadata.analysis.gps_track[0];
+				refLat = first.lat_deg;
+				refLon = first.lon_deg;
+			}
+
+			// --- Setpoint trajectory (vehicle_local_position_setpoint) ---
+			let spX: Float64Array | null = null;
+			let spY: Float64Array | null = null;
+			if (topics.has('vehicle_local_position_setpoint')) {
+				const r = await session.queryTopic('vehicle_local_position_setpoint', ['x', 'y']);
+				if (r) {
+					spX = r.series[0];
+					spY = r.series[1];
+				}
+			}
+
+			// --- GPS projected (vehicle_gps_position) ---
+			// Field names vary by firmware: newer logs use latitude_deg/longitude_deg
+			// (already in degrees), older ones use lat/lon (1e7 integers).
+			let gpsN: number[] = [];
+			let gpsE: number[] = [];
+			if (topics.has('vehicle_gps_position') && refLat != null && refLon != null) {
+				const gpsSchema = await session.getTopicSchema('vehicle_gps_position');
+				const names = new Set(gpsSchema.map((c) => c.name));
+				let latField: string | null = null;
+				let lonField: string | null = null;
+				let degScale = 1;
+				if (names.has('latitude_deg') && names.has('longitude_deg')) {
+					latField = 'latitude_deg';
+					lonField = 'longitude_deg';
+				} else if (names.has('lat') && names.has('lon')) {
+					latField = 'lat';
+					lonField = 'lon';
+					degScale = 1e-7; // older PX4: int32 * 1e-7
+				}
+				if (latField && lonField) {
+					const r = await session.queryTopic('vehicle_gps_position', [latField, lonField]);
+					if (r) {
+						const lats = r.series[0];
+						const lons = r.series[1];
+						for (let i = 0; i < lats.length; i++) {
+							const lat = lats[i] * degScale;
+							const lon = lons[i] * degScale;
+							if (lat === 0 && lon === 0) continue;
+							if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;
+							const [n, e] = projectLatLon(lat, lon, refLat, refLon);
+							gpsN.push(n);
+							gpsE.push(e);
+						}
+					}
+				}
+			}
+
+			// --- Position setpoint markers (position_setpoint_triplet.current) ---
+			// Field names vary across firmware versions; probe the schema and pick
+			// whichever XY-style or lat/lon fields are present.
+			let markerN: number[] = [];
+			let markerE: number[] = [];
+			if (topics.has('position_setpoint_triplet') && refLat != null && refLon != null) {
+				const tripletSchema = await session.getTopicSchema('position_setpoint_triplet');
+				const names = new Set(tripletSchema.map((c) => c.name));
+				const tryPairs: Array<{ x: string; y: string; mode: 'xy' | 'latlon' }> = [
+					{ x: 'current.x', y: 'current.y', mode: 'xy' },
+					{ x: 'current.lat', y: 'current.lon', mode: 'latlon' },
+				];
+				for (const pair of tryPairs) {
+					if (!names.has(pair.x) || !names.has(pair.y)) continue;
+					const r = await session.queryTopic('position_setpoint_triplet', [pair.x, pair.y]);
+					if (!r) continue;
+					const xs = r.series[0];
+					const ys = r.series[1];
+					let lastX = NaN;
+					let lastY = NaN;
+					for (let i = 0; i < xs.length; i++) {
+						if (xs[i] === lastX && ys[i] === lastY) continue;
+						lastX = xs[i];
+						lastY = ys[i];
+						if (!Number.isFinite(xs[i]) || !Number.isFinite(ys[i])) continue;
+						if (pair.mode === 'latlon') {
+							if (xs[i] === 0 && ys[i] === 0) continue;
+							const [n, e] = projectLatLon(xs[i], ys[i], refLat, refLon);
+							markerN.push(n);
+							markerE.push(e);
+						} else {
+							markerN.push(xs[i]);
+							markerE.push(ys[i]);
+						}
+					}
+					break;
+				}
+			}
+
+			// Convert Float64Array slices into plain arrays of (east, north).
+			// Note: PX4 NED convention has x=North, y=East. We display east on the
+			// horizontal axis and north on the vertical axis (top-down map view).
+			estSeries = null;
+			spSeries = null;
+			gpsSeries = null;
+			markerSeries = null;
+			if (estX && estY && estX.length > 0) {
+				estSeries = { east: Array.from(estY), north: Array.from(estX) };
+			}
+			if (spX && spY && spX.length > 0) {
+				spSeries = { east: Array.from(spY), north: Array.from(spX) };
+			}
+			if (gpsE.length > 0) {
+				gpsSeries = { east: gpsE, north: gpsN };
+			}
+			if (markerE.length > 0) {
+				markerSeries = { east: markerE, north: markerN };
+			}
+
+			if (!estSeries && !spSeries && !gpsSeries && !markerSeries) {
+				// Nothing to plot — auto-remove.
+				removePlot();
+				return;
+			}
+
+			loading = false;
+			// Wait for the canvas to mount, then draw. Retry on next frame if the
+			// container hasn't been laid out yet (width=0).
+			const tryRender = () => {
+				const w = containerEl?.getBoundingClientRect().width ?? 0;
+				if (w > 0) {
+					render(w);
+				} else {
+					requestAnimationFrame(tryRender);
+				}
+			};
+			requestAnimationFrame(tryRender);
+		} catch (e) {
+			console.error('TrajectoryPlot load error:', e);
+			error = e instanceof Error ? e.message : 'Failed to load trajectory data';
+			loading = false;
+		}
+	}
+
+	onMount(() => {
+		if (containerEl) {
+			resizeObserver = new ResizeObserver((entries) => {
+				for (const entry of entries) {
+					const w = entry.contentRect.width;
+					if (w > 0) {
+						plotHeight = w < 640 ? 280 : 460;
+						render(w);
+					}
+				}
+			});
+			resizeObserver.observe(containerEl);
+		}
+		loadAndRender();
+	});
+
+	onDestroy(() => {
+		if (resizeObserver) {
+			resizeObserver.disconnect();
+			resizeObserver = null;
+		}
+	});
+</script>
+
+<div class="rounded-lg ring-1 ring-gray-200 bg-white overflow-hidden" bind:this={containerEl}>
+	<div class="flex items-center justify-between px-2 sm:px-4 py-2 sm:py-2.5 border-b border-gray-100">
+		<div class="flex flex-wrap items-center gap-2 sm:gap-4">
+			{#if onDragStart}
+				<div
+					class="hidden md:flex items-center cursor-grab active:cursor-grabbing text-gray-300 hover:text-gray-500"
+					draggable="true"
+					ondragstart={onDragStart}
+					ondragend={onDragEnd}
+					role="button"
+					tabindex="0"
+					aria-label="Drag to reorder"
+				>
+					<svg class="size-5" viewBox="0 0 20 20" fill="currentColor">
+						<circle cx="7" cy="4" r="1.5" /><circle cx="13" cy="4" r="1.5" />
+						<circle cx="7" cy="10" r="1.5" /><circle cx="13" cy="10" r="1.5" />
+						<circle cx="7" cy="16" r="1.5" /><circle cx="13" cy="16" r="1.5" />
+					</svg>
+				</div>
+				<div class="flex md:hidden flex-col -space-y-0.5">
+					<button
+						class="text-gray-400 hover:text-gray-600 disabled:opacity-30 disabled:cursor-default"
+						onclick={onMoveUp}
+						disabled={index === 0}
+						aria-label="Move plot up"
+					>
+						<svg class="size-3.5" viewBox="0 0 20 20" fill="currentColor">
+							<path fill-rule="evenodd" d="M10 3.293l-6.354 6.353a1 1 0 001.415 1.414L10 6.121l4.939 4.939a1 1 0 001.414-1.414L10 3.293z" clip-rule="evenodd" />
+						</svg>
+					</button>
+					<button
+						class="text-gray-400 hover:text-gray-600 disabled:opacity-30 disabled:cursor-default"
+						onclick={onMoveDown}
+						disabled={index === (totalCount ?? 1) - 1}
+						aria-label="Move plot down"
+					>
+						<svg class="size-3.5" viewBox="0 0 20 20" fill="currentColor">
+							<path fill-rule="evenodd" d="M10 16.707l6.354-6.353a1 1 0 00-1.415-1.414L10 13.879l-4.939-4.939a1 1 0 00-1.414 1.414L10 16.707z" clip-rule="evenodd" />
+						</svg>
+					</button>
+				</div>
+			{/if}
+			<span class="text-xs sm:text-sm font-medium text-gray-900">{config.yLabel || '2D Trajectory'}</span>
+			<div class="flex flex-wrap items-center gap-x-1.5 sm:gap-x-3 gap-y-1 text-xs">
+				{#each LEGEND as item}
+					<span class="flex items-center gap-1.5">
+						{#if item.marker}
+							<span class="inline-block w-2.5 h-2.5 rounded-full border-2" style="border-color: {item.color};"></span>
+						{:else}
+							<span class="w-3 h-0.5 rounded" style="background-color: {item.color};"></span>
+						{/if}
+						<span class="text-gray-500">{item.label}</span>
+					</span>
+				{/each}
+			</div>
+		</div>
+		<div class="flex items-center gap-1">
+			<button class="text-gray-400 hover:text-gray-600" onclick={downloadPng} aria-label="Download as PNG">
+				<svg class="size-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+					<path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12M12 16.5V3" />
+				</svg>
+			</button>
+			<button class="text-gray-400 hover:text-gray-600" onclick={() => togglePlotMinimized(config.id)} aria-label={config.minimized ? 'Expand plot' : 'Minimize plot'}>
+				<svg class="size-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+					{#if config.minimized}
+						<path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+					{:else}
+						<path stroke-linecap="round" stroke-linejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
+					{/if}
+				</svg>
+			</button>
+			<button class="text-gray-400 hover:text-gray-600" onclick={removePlot} aria-label="Remove plot">
+				<svg class="size-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+					<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+				</svg>
+			</button>
+		</div>
+	</div>
+	<div
+		class="relative bg-gray-50 transition-all duration-200 ease-in-out"
+		style="min-height: {config.minimized ? 0 : plotHeight}px; max-height: {config.minimized ? '0px' : 'none'}; overflow: {config.minimized ? 'hidden' : 'visible'};"
+	>
+		{#if loading}
+			<div class="absolute inset-0 flex items-center justify-center">
+				<svg class="size-6 animate-spin text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+					<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+					<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+				</svg>
+				<span class="ml-2 text-sm text-gray-400">Loading trajectory...</span>
+			</div>
+		{:else if error}
+			<div class="absolute inset-0 flex items-center justify-center">
+				<div class="text-center">
+					<svg class="size-8 text-red-300 mx-auto mb-2" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+					</svg>
+					<p class="text-sm text-red-500">{error}</p>
+				</div>
+			</div>
+		{/if}
+		<canvas bind:this={canvasEl} class="block w-full"></canvas>
+	</div>
+</div>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -211,4 +211,7 @@ export interface PlotConfig {
   yLabel: string;
   colors: string[];
   minimized?: boolean;
+  /** Plot rendering kind. 'timeseries' (default) plots fields vs time;
+   *  'xy' is a special trajectory/scatter plot with hardcoded topics. */
+  kind?: 'timeseries' | 'xy';
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -212,6 +212,7 @@ export interface PlotConfig {
   colors: string[];
   minimized?: boolean;
   /** Plot rendering kind. 'timeseries' (default) plots fields vs time;
-   *  'xy' is a special trajectory/scatter plot with hardcoded topics. */
-  kind?: 'timeseries' | 'xy';
+   *  'xy' is a special trajectory/scatter plot with hardcoded topics;
+   *  'spectrogram' is a PSD heatmap with hardcoded topics. */
+  kind?: 'timeseries' | 'xy' | 'spectrogram';
 }

--- a/frontend/src/lib/utils/formatters.ts
+++ b/frontend/src/lib/utils/formatters.ts
@@ -18,6 +18,36 @@ export function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
 }
 
+/**
+ * Try to extract a flight date/time from a PX4 log filename.
+ * PX4 default naming: `log_N_YYYY-M-D-HH-MM-SS.ulg` or `YYYY-MM-DD/HH_MM_SS.ulg`.
+ * Returns a Date if a plausible timestamp is found, else null.
+ */
+export function parseFlightDateFromFilename(filename: string | null | undefined): Date | null {
+  if (!filename) return null;
+  // Pattern A: YYYY-M-D-HH-MM-SS (PX4 default, e.g. log_13_2024-3-15-12-34-56.ulg)
+  const a = filename.match(/(\d{4})-(\d{1,2})-(\d{1,2})-(\d{1,2})-(\d{1,2})-(\d{1,2})/);
+  if (a) {
+    const [, y, mo, d, h, mi, s] = a;
+    const date = new Date(Date.UTC(+y, +mo - 1, +d, +h, +mi, +s));
+    if (!isNaN(date.getTime())) return date;
+  }
+  // Pattern B: YYYY-MM-DD separate from HH_MM_SS (e.g. 2024-03-15/12_34_56.ulg)
+  const b = filename.match(/(\d{4})-(\d{2})-(\d{2})[^\d]+(\d{2})[_-](\d{2})[_-](\d{2})/);
+  if (b) {
+    const [, y, mo, d, h, mi, s] = b;
+    const date = new Date(Date.UTC(+y, +mo - 1, +d, +h, +mi, +s));
+    if (!isNaN(date.getTime())) return date;
+  }
+  return null;
+}
+
+export function formatFlightDateTime(date: Date): { date: string; time: string } {
+  const d = date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+  const t = date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+  return { date: d, time: t };
+}
+
 export function formatRelativeTime(dateStr: string): string {
   const date = new Date(dateStr);
   const now = new Date();

--- a/frontend/src/lib/utils/paramExport.ts
+++ b/frontend/src/lib/utils/paramExport.ts
@@ -1,0 +1,65 @@
+/**
+ * Parameter file export utilities.
+ *
+ * Supports the QGroundControl `.params` format (tab-separated), which can be
+ * loaded back into QGC or MAVLink tools to replicate a vehicle's configuration.
+ *
+ * Format (one header block, then one row per parameter):
+ *   # Onboard parameters for Vehicle <id>
+ *   #
+ *   # Vehicle-Id Component-Id Name Value Type
+ *   1\t1\tPARAM_NAME\t<value>\t<type>
+ *
+ * Type codes follow MAV_PARAM_TYPE. We emit 9 (REAL32) for all values since the
+ * backend exposes parameters as plain numbers without type discrimination — QGC
+ * accepts this on import.
+ */
+
+const MAV_PARAM_TYPE_REAL32 = 9;
+
+export interface ParamFileOptions {
+  sysName?: string | null;
+  vehicleId?: number;
+  componentId?: number;
+}
+
+/** Format a single param value for the QGC params file. */
+function formatValue(value: number): string {
+  if (Number.isInteger(value)) return value.toFixed(1);
+  // Use enough precision to round-trip float32 values.
+  return value.toPrecision(9).replace(/0+$/, '').replace(/\.$/, '.0');
+}
+
+/** Build the contents of a QGC `.params` file from a parameter dictionary. */
+export function buildQgcParamsFile(
+  parameters: Record<string, number>,
+  options: ParamFileOptions = {}
+): string {
+  const { sysName, vehicleId = 1, componentId = 1 } = options;
+  const names = Object.keys(parameters).sort();
+
+  const header = [
+    `# Onboard parameters for Vehicle ${sysName ?? vehicleId}`,
+    '#',
+    '# Vehicle-Id Component-Id Name Value Type',
+  ];
+
+  const rows = names.map((name) =>
+    [vehicleId, componentId, name, formatValue(parameters[name]), MAV_PARAM_TYPE_REAL32].join('\t')
+  );
+
+  return header.concat(rows).join('\n') + '\n';
+}
+
+/** Trigger a browser download of the given text content. */
+export function downloadTextFile(filename: string, content: string, mime = 'text/plain'): void {
+  const blob = new Blob([content], { type: `${mime};charset=utf-8` });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/frontend/src/lib/utils/spectrogram.ts
+++ b/frontend/src/lib/utils/spectrogram.ts
@@ -1,0 +1,138 @@
+/**
+ * Short-Time Fourier Transform (STFT) for spectrogram computation.
+ *
+ * Mirrors scipy.signal.spectrogram(window='hann', nperseg=N, noverlap=N/2,
+ * scaling='density') so the output matches v1 flight_review's PSD plot.
+ *
+ * Output shape: { freqs[nFreq], times[nTime], psd[nFreq * nTime] (row-major
+ * by frequency, i.e. psd[f * nTime + t]) }
+ */
+
+import FFT from 'fft.js';
+
+export interface SpectrogramResult {
+  /** Frequencies in Hz, length = nperseg / 2 + 1 */
+  freqs: Float64Array;
+  /** Center times of each window in seconds (relative to first sample) */
+  times: Float64Array;
+  /** PSD values, row-major: psd[f * nTime + t] */
+  psd: Float64Array;
+  nFreq: number;
+  nTime: number;
+}
+
+/** Build a periodic Hann window of the given length (matches scipy default). */
+function hannWindow(n: number): Float64Array {
+  const w = new Float64Array(n);
+  for (let i = 0; i < n; i++) {
+    w[i] = 0.5 * (1 - Math.cos((2 * Math.PI * i) / n));
+  }
+  return w;
+}
+
+/**
+ * Compute the PSD spectrogram of a single real-valued signal using
+ * scipy-compatible 'density' scaling.
+ */
+export function computePsdSpectrogram(
+  signal: Float64Array | number[],
+  fs: number,
+  nperseg = 256,
+  noverlap = 128
+): SpectrogramResult | null {
+  if (signal.length < nperseg) return null;
+  if (nperseg <= 0 || (nperseg & (nperseg - 1)) !== 0) {
+    // fft.js requires a power of two
+    return null;
+  }
+
+  const win = hannWindow(nperseg);
+  let winSumSq = 0;
+  for (let i = 0; i < nperseg; i++) winSumSq += win[i] * win[i];
+
+  // density scale: 1 / (Fs * sum(win^2))
+  const scale = 1 / (fs * winSumSq);
+
+  const step = nperseg - noverlap;
+  const nTime = Math.floor((signal.length - nperseg) / step) + 1;
+  const nFreq = nperseg / 2 + 1;
+
+  const fft = new FFT(nperseg);
+  const segIn = new Float64Array(nperseg);
+  const out = fft.createComplexArray() as number[]; // length = 2*nperseg
+
+  const psd = new Float64Array(nFreq * nTime);
+
+  for (let t = 0; t < nTime; t++) {
+    const start = t * step;
+    // window the segment
+    for (let i = 0; i < nperseg; i++) {
+      segIn[i] = signal[start + i] * win[i];
+    }
+    fft.realTransform(out, segIn as any);
+    // Note: realTransform only fills the first half (n complex pairs); use
+    // those directly. out layout = [re0, im0, re1, im1, ..., re(n/2), im(n/2)].
+    for (let k = 0; k < nFreq; k++) {
+      const re = out[2 * k];
+      const im = out[2 * k + 1];
+      let p = (re * re + im * im) * scale;
+      // One-sided: double everything except DC (k=0) and Nyquist (k=nFreq-1)
+      if (k > 0 && k < nFreq - 1) p *= 2;
+      psd[k * nTime + t] = p;
+    }
+  }
+
+  // Frequency bins
+  const freqs = new Float64Array(nFreq);
+  for (let k = 0; k < nFreq; k++) freqs[k] = (k * fs) / nperseg;
+
+  // Center times of each window (matches scipy output)
+  const times = new Float64Array(nTime);
+  for (let t = 0; t < nTime; t++) {
+    times[t] = (t * step + nperseg / 2) / fs;
+  }
+
+  return { freqs, times, psd, nFreq, nTime };
+}
+
+/**
+ * Sum multiple PSD spectrograms element-wise (matches v1's per-axis sum).
+ * All inputs must have the same shape.
+ */
+export function sumPsd(specs: SpectrogramResult[]): SpectrogramResult | null {
+  if (specs.length === 0) return null;
+  const first = specs[0];
+  const out = new Float64Array(first.psd.length);
+  for (const s of specs) {
+    if (s.psd.length !== out.length) return null;
+    for (let i = 0; i < out.length; i++) out[i] += s.psd[i];
+  }
+  return { ...first, psd: out };
+}
+
+/** Convert PSD to dB in-place: 20 → 10*log10(x). Replaces -inf with the
+ *  smallest finite value found, matching v1 behavior. */
+export function psdToDb(psd: Float64Array): { min: number; max: number } {
+  let min = Infinity;
+  let max = -Infinity;
+  for (let i = 0; i < psd.length; i++) {
+    const v = psd[i];
+    if (v > 0) {
+      const db = 10 * Math.log10(v);
+      psd[i] = db;
+      if (db < min) min = db;
+      if (db > max) max = db;
+    } else {
+      psd[i] = -Infinity;
+    }
+  }
+  if (!Number.isFinite(min)) {
+    min = -120;
+    max = 0;
+  }
+  // Replace -inf with finite min
+  for (let i = 0; i < psd.length; i++) {
+    if (!Number.isFinite(psd[i])) psd[i] = min;
+  }
+  return { min, max };
+}

--- a/frontend/src/lib/utils/viridis.ts
+++ b/frontend/src/lib/utils/viridis.ts
@@ -1,0 +1,48 @@
+/**
+ * Viridis colormap (256 entries) — perceptually uniform sequential colormap
+ * matching Bokeh's Viridis256 / matplotlib's viridis.
+ *
+ * The full 256-entry table would add ~3KB. Instead we sample 17 stops at
+ * even intervals from the official lookup and linearly interpolate. The
+ * resulting colors are visually indistinguishable from the full table for
+ * a heatmap rendering.
+ */
+
+// 17 stops at i/16 from the matplotlib viridis lookup table.
+const STOPS: Array<[number, number, number]> = [
+  [68, 1, 84],     // 0.000
+  [72, 26, 108],   // 0.0625
+  [71, 47, 124],   // 0.125
+  [65, 68, 135],   // 0.1875
+  [57, 86, 140],   // 0.25
+  [49, 104, 142],  // 0.3125
+  [42, 120, 142],  // 0.375
+  [37, 134, 142],  // 0.4375
+  [32, 145, 140],  // 0.5
+  [31, 158, 137],  // 0.5625
+  [37, 171, 130],  // 0.625
+  [55, 184, 120],  // 0.6875
+  [85, 196, 104],  // 0.75
+  [121, 206, 84],  // 0.8125
+  [161, 215, 60],  // 0.875
+  [201, 222, 35],  // 0.9375
+  [253, 231, 37],  // 1.000
+];
+
+/**
+ * Sample the viridis colormap at t ∈ [0, 1]. Returns [r, g, b] in 0..255.
+ */
+export function viridis(t: number): [number, number, number] {
+  if (!(t > 0)) return STOPS[0];
+  if (t >= 1) return STOPS[STOPS.length - 1];
+  const scaled = t * (STOPS.length - 1);
+  const i = Math.floor(scaled);
+  const frac = scaled - i;
+  const a = STOPS[i];
+  const b = STOPS[i + 1];
+  return [
+    Math.round(a[0] + (b[0] - a[0]) * frac),
+    Math.round(a[1] + (b[1] - a[1]) * frac),
+    Math.round(a[2] + (b[2] - a[2]) * frac),
+  ];
+}

--- a/frontend/src/routes/log/[id]/+layout.svelte
+++ b/frontend/src/routes/log/[id]/+layout.svelte
@@ -12,6 +12,7 @@
 	import FlightSummaryHeader from '$lib/components/viewer/FlightSummaryHeader.svelte';
 	import FlightModeTimeline from '$lib/components/viewer/FlightModeTimeline.svelte';
 	import PlotBuilderPanel from '$lib/components/viewer/PlotBuilderPanel.svelte';
+	import { buildQgcParamsFile, downloadTextFile } from '$lib/utils/paramExport';
 
 	let { children } = $props<{ children: Snippet }>();
 
@@ -94,6 +95,14 @@
 	function resetZoom() {
 		timeRange.set(null);
 	}
+
+	function downloadParams() {
+		if (!metadata?.parameters || !logRecord) return;
+		const content = buildQgcParamsFile(metadata.parameters, { sysName: metadata.sys_name });
+		// Strip any extension from the source filename and append `.params`.
+		const base = logRecord.filename?.replace(/\.[^.]+$/, '') || logRecord.id;
+		downloadTextFile(`${base}.params`, content);
+	}
 </script>
 
 <svelte:head>
@@ -164,6 +173,19 @@
 										<path stroke-linecap="round" stroke-linejoin="round" d="M9 9V4.5M9 9H4.5M9 9L3.75 3.75M9 15v4.5M9 15H4.5M9 15l-5.25 5.25M15 9h4.5M15 9V4.5M15 9l5.25-5.25M15 15h4.5M15 15v4.5m0-4.5l5.25 5.25" />
 									</svg>
 									<span class="hidden sm:inline">Reset Zoom</span>
+								</button>
+							{/if}
+							{#if activeTab === '/parameters'}
+								<button
+									class="flex items-center gap-1.5 rounded-md bg-indigo-600 px-2 sm:px-3 py-1 text-xs font-medium text-white hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+									onclick={downloadParams}
+									disabled={!metadata?.parameters || Object.keys(metadata.parameters).length === 0}
+									title="Download parameters as QGroundControl .params file"
+								>
+									<svg class="size-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+										<path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12M12 16.5V3" />
+									</svg>
+									<span class="hidden lg:inline">Download .params</span>
 								</button>
 							{/if}
 						</div>

--- a/frontend/src/routes/log/[id]/+layout.svelte
+++ b/frontend/src/routes/log/[id]/+layout.svelte
@@ -124,7 +124,7 @@
 
 		<!-- Sticky header: summary + flight modes + tab bar -->
 		<div class="sticky top-0 z-30 bg-white shadow-sm">
-			<FlightSummaryHeader {metadata} logId={logRecord.id} vehicleType={logRecord.vehicle_type} locationName={logRecord.location_name} />
+			<FlightSummaryHeader {metadata} logId={logRecord.id} vehicleType={logRecord.vehicle_type} locationName={logRecord.location_name} filename={logRecord.filename} createdAt={logRecord.created_at} />
 
 			{#if metadata.analysis?.flight_modes && metadata.analysis.flight_modes.length > 0}
 				<FlightModeTimeline segments={metadata.analysis.flight_modes} />

--- a/frontend/src/routes/log/[id]/+page.svelte
+++ b/frontend/src/routes/log/[id]/+page.svelte
@@ -69,6 +69,7 @@
 	];
 
 	const TRAJECTORY_PLOT_ID = 'trajectory_2d';
+	const ACCEL_SPECTROGRAM_ID = 'accel_spectrogram';
 
 	function makeTrajectoryPlot(): PlotConfig {
 		return {
@@ -79,6 +80,18 @@
 			yLabel: '2D Trajectory',
 			colors: [],
 			kind: 'xy',
+		};
+	}
+
+	function makeAccelSpectrogramPlot(): PlotConfig {
+		return {
+			id: ACCEL_SPECTROGRAM_ID,
+			topic: 'sensor_combined',
+			multiId: 0,
+			fields: [],
+			yLabel: 'Acceleration Power Spectral Density',
+			colors: [],
+			kind: 'spectrogram',
 		};
 	}
 
@@ -104,6 +117,12 @@
 			});
 		}
 
+		// Acceleration spectrogram appended after the time-series defaults so it
+		// doesn't push the more commonly inspected plots below the fold.
+		if (availableTopics.has('sensor_combined')) {
+			plots.push(makeAccelSpectrogramPlot());
+		}
+
 		return plots;
 	}
 
@@ -124,6 +143,13 @@
 						!valid.some((p) => p.id === TRAJECTORY_PLOT_ID)
 					) {
 						valid.unshift(makeTrajectoryPlot());
+					}
+					// Append the spectrogram if missing.
+					if (
+						availableTopics.has('sensor_combined') &&
+						!valid.some((p) => p.id === ACCEL_SPECTROGRAM_ID)
+					) {
+						valid.push(makeAccelSpectrogramPlot());
 					}
 					activePlots.set(valid);
 				} else {

--- a/frontend/src/routes/log/[id]/+page.svelte
+++ b/frontend/src/routes/log/[id]/+page.svelte
@@ -68,9 +68,28 @@
 		['cpu', 'cpuload', 0, ['load', 'ram_usage'], 'CPU Load'],
 	];
 
+	const TRAJECTORY_PLOT_ID = 'trajectory_2d';
+
+	function makeTrajectoryPlot(): PlotConfig {
+		return {
+			id: TRAJECTORY_PLOT_ID,
+			topic: 'vehicle_local_position',
+			multiId: 0,
+			fields: [],
+			yLabel: '2D Trajectory',
+			colors: [],
+			kind: 'xy',
+		};
+	}
+
 	function buildDefaultPlots(metadata: FlightMetadata): PlotConfig[] {
 		const availableTopics = new Set(Object.keys(metadata.topics));
 		const plots: PlotConfig[] = [];
+
+		// Trajectory plot is always first when local position data is available.
+		if (availableTopics.has('vehicle_local_position')) {
+			plots.push(makeTrajectoryPlot());
+		}
 
 		for (const [id, topic, multiId, fields, yLabel] of DEFAULT_PLOTS) {
 			if (!availableTopics.has(topic)) continue;
@@ -98,6 +117,14 @@
 			if (saved && saved.length > 0) {
 				const valid = saved.filter((p) => availableTopics.has(p.topic));
 				if (valid.length > 0) {
+					// Prepend the trajectory plot if missing from saved layout (so existing
+					// users pick up the new default the first time they reopen a log).
+					if (
+						availableTopics.has('vehicle_local_position') &&
+						!valid.some((p) => p.id === TRAJECTORY_PLOT_ID)
+					) {
+						valid.unshift(makeTrajectoryPlot());
+					}
 					activePlots.set(valid);
 				} else {
 					activePlots.set(buildDefaultPlots(ctx.metadata));


### PR DESCRIPTION
A grab-bag of plot-tab and viewer improvements that bring the v2 viewer closer to v1 flight_review feature parity.

The biggest additions are two new default plots that match v1: a 2D trajectory overlay (estimated position, setpoint, GPS-projected track, and position setpoint markers) and an acceleration power spectral density spectrogram (Hann-windowed STFT of `sensor_combined.accelerometer_m_s2[0..2]`, summed across axes, dB scale, viridis colormap). Both are pure client-side, computed in the browser from the parquet files the converter already produces, so no backend changes were needed. The spectrogram pulls in [`fft.js`](https://github.com/indutny/fft.js) (MIT, zero deps, ~5 KB) for the radix-4 FFT.

Other changes:
- Map view now uses Mapbox `satellite-streets-v12` to match v1's imagery
- Flight date/time pill in the summary header, parsed from the PX4 filename when available, falling back to upload time
- Parameters tab gains a QGroundControl `.params` file download button (icon-only on mobile/tablet)
- `PlotConfig` gains a `kind` discriminator (`'timeseries' | 'xy' | 'spectrogram'`); `DragDropPlotList` dispatches each kind to the right component
- The trajectory and spectrogram plots are also injected into saved layouts on first load, so existing users pick up the new defaults without losing their customizations
- A couple of small fixes: a11y warning on the drag-drop list, stale prop reference in `ParamDiffPanel`, and a copied `frontend/.env` for Mapbox token loading in worktrees