### PR TITLE
Escalate vibration status on peak, not just mean

### DIFF
--- a/crates/converter/src/analysis.rs
+++ b/crates/converter/src/analysis.rs
@@ -91,7 +91,9 @@ pub struct GpsQuality {
 pub struct VibrationSummary {
     pub accel_vibe_mean: Option<f64>,
     pub accel_vibe_max: Option<f64>,
-    /// "good" (< 4.905), "warning" (4.905-9.81), "critical" (> 9.81)
+    /// Worst of the mean and peak classifications.
+    /// Mean thresholds: good < 4.905, warning < 9.81, critical >= 9.81.
+    /// Max thresholds:  good < 9.81,  warning < 19.62, critical >= 19.62.
     pub status: String,
 }
 
@@ -835,14 +837,30 @@ pub fn analyze(path: &str, metadata: &FlightMetadata) -> Result<FlightAnalysis, 
     // --- Finalize vibration ---
     if vibe_count > 0 {
         let mean = vibe_sum / vibe_count as f64;
+        let max = vibe_max as f64;
         analysis.vibration.accel_vibe_mean = Some(mean);
-        analysis.vibration.accel_vibe_max = Some(vibe_max as f64);
-        analysis.vibration.status = if mean < 4.905 {
-            "good".to_string()
+        analysis.vibration.accel_vibe_max = Some(max);
+        // Status escalates on either the mean or the peak. A short but severe
+        // vibration burst (e.g. accel clipping) can leave the mean low while the
+        // peak is well into critical territory, so gate on both.
+        let mean_status = if mean < 4.905 {
+            0
         } else if mean < 9.81 {
-            "warning".to_string()
+            1
         } else {
-            "critical".to_string()
+            2
+        };
+        let max_status = if max < 9.81 {
+            0
+        } else if max < 19.62 {
+            1
+        } else {
+            2
+        };
+        analysis.vibration.status = match mean_status.max(max_status) {
+            0 => "good".to_string(),
+            1 => "warning".to_string(),
+            _ => "critical".to_string(),
         };
     }
 


### PR DESCRIPTION
The vibration analyzer was gating `status` only on `accel_vibe_mean`, so a log with a low mean but a severe short burst (e.g. accel clipping) came back `"good"`. This changes the finalize step in `crates/converter/src/analysis.rs` to take the worst of the mean and peak classifications, with max thresholds of 9.81 m/s² (warning) and 19.62 m/s² (critical).

Verified against the log from #13 (`d8852605-ac7e-46fa-bbff-8fd977b24f0e`): `accel_vibe_mean` 3.13, `accel_vibe_max` 34.37, status now reports `critical` instead of `good`. That log was from the fixed-wing incident behind PX4/PX4-Autopilot#27013, where the vibration precipitated an EKF2 selector failure and near-crash, so it should absolutely not come back clean.

Fixes #13