### PR TITLE
docs(diagnostics): add contributor guide for new analyzers

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,21 +544,9 @@ curl "http://localhost:8080/api/logs?diagnostic_severity=critical"
 
 ### Adding a New Analyzer
 
-1. Create `crates/converter/src/diagnostics/your_analyzer.rs`
-2. Add a variant to the `Evidence` enum in `mod.rs`
-3. Implement the `Analyzer` trait (`id`, `description`, `required_topics`, `on_message`, `finish`)
-4. Register in `create_analyzers()` and declare with `pub mod`
-5. Add a real-world `.ulg` fixture in `tests/fixtures/` that exhibits the failure
-6. Write tests following the required pattern (see `testing.rs`):
-   - No false positives on `sample.ulg`
-   - Detection on real-world fixture
-   - Detection on synthetic data via `MessageBuilder`
-   - Missing fields don't panic
-   - Deduplication
-   - `insta` snapshot test
-7. Run `cargo bench` and include results in the PR
+See the full contributor guide at [`crates/converter/src/diagnostics/CONTRIBUTING.md`](crates/converter/src/diagnostics/CONTRIBUTING.md). It walks through the five steps (add an `Evidence` variant, create the analyzer file, register it, write the required tests, run the CI gates locally), includes a copy-pasteable skeleton, and points at [`rc_loss.rs`](crates/converter/src/diagnostics/rc_loss.rs) as the shortest complete reference implementation.
 
-CI (`diagnostics.yml`) validates all of this automatically on PRs that touch the diagnostics directory. Run `scripts/ci/check-analyzer.sh` locally to verify before pushing.
+CI (`diagnostics.yml`) validates the pattern automatically on PRs that touch the diagnostics directory. Run `scripts/ci/check-analyzer.sh` locally to verify before pushing.
 
 ## For Researchers
 

--- a/crates/converter/src/diagnostics/CONTRIBUTING.md
+++ b/crates/converter/src/diagnostics/CONTRIBUTING.md
@@ -1,0 +1,170 @@
+# Adding a diagnostic analyzer
+
+This guide walks through adding a new analyzer to the diagnostics pipeline. The pipeline is defined in [`mod.rs`](./mod.rs) and runs during the streaming `analyze()` pass: each analyzer declares the ULog topics it needs, receives messages one at a time, and emits structured `Diagnostic` results at the end.
+
+If you're new to the module, read [`rc_loss.rs`](./rc_loss.rs) first — it's the shortest complete reference implementation.
+
+![Contributor workflow](./docs/workflow.svg)
+
+## What the pipeline looks like
+
+![Diagnostics pipeline](./docs/pipeline.svg)
+
+Key properties to keep in mind when designing an analyzer:
+
+- **Single-pass, streaming.** You see each message exactly once, in timestamp order. You don't get a random-access view of the whole log. If your detection needs a window, buffer it yourself inside the analyzer struct.
+- **One log at a time.** There is no batch/training phase. If your detector needs prior data (e.g. a trained model), it has to be baked into the binary as a constant, loaded from disk at startup, or derived from the current log's early samples before you start emitting results.
+- **Topic-scoped dispatch.** Messages are only delivered for topics you list in `required_topics()`. Don't try to filter them yourself in `on_message` — just declare what you need.
+- **Performance budget.** The whole diagnostic pass has a 500ms budget enforced by `cargo bench` in CI. A ~4MB log currently runs in ~37ms end-to-end. Stay cheap per message.
+
+## Step 1: Add an `Evidence` variant
+
+Every analyzer emits typed, structured evidence — not freeform strings or maps. The frontend matches on `evidence.type` and renders a specific UI for each variant. Changing an existing variant's fields is a breaking schema change, so pick field names carefully the first time.
+
+Edit [`mod.rs`](./mod.rs) and add your variant:
+
+```rust
+pub enum Evidence {
+    // ... existing variants ...
+    ZAxisVibrationAnomaly {
+        score: f32,
+        peak_accel_m_s2: f32,
+        window_start_us: u64,
+        window_end_us: u64,
+    },
+}
+```
+
+Also bump `ANALYSIS_VERSION` in the same file when your analyzer is ready to ship. That tells the reprocessing pipeline historical logs need a re-scan.
+
+## Step 2: Create the analyzer file
+
+Create `crates/converter/src/diagnostics/your_analyzer.rs`. Minimal skeleton:
+
+```rust
+//! Short description of what this analyzer detects and how.
+//!
+//! Topics consumed, thresholds used, and any known limitations or fixture gaps
+//! (use SKIP_FIXTURE: <reason> if no real-world log exists yet).
+
+use super::{parse_field, Analyzer, Diagnostic, Evidence, Severity};
+use px4_ulog::stream_parser::model::DataMessage;
+
+const SOME_THRESHOLD: f32 = 2.5;
+
+pub struct YourAnalyzer {
+    // Per-flight state. Reset per log.
+    detections: Vec<Diagnostic>,
+}
+
+impl Default for YourAnalyzer {
+    fn default() -> Self { Self::new() }
+}
+
+impl YourAnalyzer {
+    pub fn new() -> Self {
+        Self { detections: Vec::new() }
+    }
+}
+
+impl Analyzer for YourAnalyzer {
+    fn id(&self) -> &str { "your_analyzer" }
+
+    fn description(&self) -> &str { "One-line human description" }
+
+    fn required_topics(&self) -> &[&str] {
+        &["sensor_combined", "vehicle_status"]
+    }
+
+    fn on_message(&mut self, data: &DataMessage) {
+        let topic = data.flattened_format.message_name.as_str();
+        let ts = data
+            .flattened_format
+            .timestamp_field
+            .as_ref()
+            .map(|tf| tf.parse_timestamp(data.data))
+            .unwrap_or(0);
+
+        match topic {
+            "sensor_combined" => {
+                let Some(az) = parse_field::<f32>(data, "accelerometer_m_s2[2]") else {
+                    return;
+                };
+                // ... update state, maybe push to self.detections ...
+                let _ = (ts, az);
+            }
+            _ => {}
+        }
+    }
+
+    fn finish(self: Box<Self>) -> Vec<Diagnostic> {
+        self.detections
+    }
+}
+```
+
+Notes on the trait methods:
+
+- **`id()`** is the stable machine identifier stored in the database and exposed via the API's `?diagnostic=` filter. Don't change it after release.
+- **`required_topics()`** must match the exact ULog topic names. Typos mean your analyzer silently never runs.
+- **`on_message()`** must not panic and must handle missing fields gracefully — use `parse_field::<T>()`, which returns `Option<T>`, never unwrap.
+- **`finish()`** takes `Box<Self>` (the pipeline owns the analyzers). Move your accumulated detections out and return them.
+
+## Step 3: Register it
+
+In [`mod.rs`](./mod.rs), add your analyzer to `create_analyzers()`:
+
+```rust
+pub fn create_analyzers() -> Vec<Box<dyn Analyzer>> {
+    vec![
+        // ... existing ones ...
+        Box::new(your_analyzer::YourAnalyzer::new()),
+    ]
+}
+```
+
+And add the `pub mod your_analyzer;` declaration at the top of the file.
+
+Until you do this, nothing in the pipeline will ever construct or call your analyzer. This is the step most first-time contributors miss.
+
+## Step 4: Write the required tests
+
+CI runs [`scripts/ci/check-analyzer.sh`](../../../../scripts/ci/check-analyzer.sh) on every PR touching this directory. It grep-checks your file for a specific test pattern. At minimum you need:
+
+1. **`no_false_positives_sample`** — runs your analyzer against `tests/fixtures/sample.ulg` (a normal flight) and asserts zero detections.
+2. **A real-world detection test** named `detects_real_*` — points at a fixture ULog that actually exhibits the anomaly, asserts the detection fires with the right severity/evidence. If no fixture exists, add `SKIP_FIXTURE: <reason>` to the module doc comment and open an issue to collect one.
+3. **`handles_missing_fields`** — feed it a message with no fields and assert it doesn't panic and emits nothing.
+4. **At least one synthetic detection test** — uses `MessageBuilder` from [`testing.rs`](./testing.rs) to construct messages by hand. This is where you pin down your detection logic with fast deterministic tests.
+5. **A snapshot test** using `insta::assert_json_snapshot!` on the fixture output. Run `cargo insta review` locally to accept the first snapshot.
+
+Copy the test block from [`rc_loss.rs`](./rc_loss.rs) and adapt it — it hits every required category.
+
+## Step 5: Run the same gates CI will
+
+Before opening a PR, run locally:
+
+```sh
+# The trait/test/registration checker CI uses
+scripts/ci/check-analyzer.sh
+
+# The diagnostic test suite
+cargo test -p flight-review --lib diagnostics
+
+# The performance budget
+cargo bench -p flight-review --bench convert
+```
+
+If `check-analyzer.sh` complains, it will tell you exactly which of the five criteria you missed. If the bench regresses past the budget, profile your `on_message` — the usual culprit is allocating or parsing the same field multiple times per message.
+
+## Common first-time mistakes
+
+- **Defining a new `Analyzer` trait.** There's already one in [`mod.rs`](./mod.rs). Implement it; don't redefine it.
+- **Putting the file outside `diagnostics/`.** It has to live in this directory, otherwise the CI checker and the registration factory won't see it.
+- **Returning `Option<String>` or a freeform summary.** Results must be `Vec<Diagnostic>` with a typed `Evidence` variant.
+- **Assuming you get the whole log at once.** You don't. Design for streaming.
+- **Pulling in heavy ML dependencies without discussing the perf/memory budget first.** The converter is zero-ML today; open an issue before adding something like `extended-isolation-forest`, `smartcore`, etc. so we can agree on how the model is trained, shipped, and benchmarked.
+- **Skipping the real-world fixture.** Synthetic tests alone don't count toward the CI gate. Either ship a fixture or mark `SKIP_FIXTURE` with a reason.
+
+## Questions
+
+Open a draft PR early and tag `@mrpollo`. Draft PRs are the right place to get architecture feedback before you go deep on implementation.

--- a/crates/converter/src/diagnostics/docs/pipeline.svg
+++ b/crates/converter/src/diagnostics/docs/pipeline.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 320" font-family="-apple-system, Segoe UI, Helvetica, Arial, sans-serif" font-size="14">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#334155"/>
+    </marker>
+    <linearGradient id="stream" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0" stop-color="#e0f2fe"/>
+      <stop offset="1" stop-color="#bae6fd"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="0" y="0" width="900" height="320" fill="#ffffff"/>
+
+  <!-- ULog source -->
+  <rect x="20" y="120" width="140" height="70" rx="10" fill="url(#stream)" stroke="#0284c7" stroke-width="1.5"/>
+  <text x="90" y="150" text-anchor="middle" font-weight="600" fill="#0c4a6e">ULog stream</text>
+  <text x="90" y="170" text-anchor="middle" fill="#0c4a6e" font-size="12">timestamp-ordered</text>
+
+  <!-- analyze() pass -->
+  <rect x="200" y="120" width="170" height="70" rx="10" fill="#f1f5f9" stroke="#475569" stroke-width="1.5"/>
+  <text x="285" y="148" text-anchor="middle" font-weight="600" fill="#0f172a">analyze() pass</text>
+  <text x="285" y="168" text-anchor="middle" fill="#475569" font-size="12">single streaming walk</text>
+
+  <!-- Dispatch fan-out -->
+  <circle cx="430" cy="155" r="10" fill="#fde68a" stroke="#b45309" stroke-width="1.5"/>
+  <text x="430" y="135" text-anchor="middle" font-size="11" fill="#78350f">dispatch</text>
+  <text x="430" y="185" text-anchor="middle" font-size="11" fill="#78350f">by topic</text>
+
+  <!-- Analyzers -->
+  <g>
+    <rect x="490" y="30" width="200" height="54" rx="8" fill="#ecfdf5" stroke="#059669" stroke-width="1.5"/>
+    <text x="590" y="52" text-anchor="middle" font-weight="600" fill="#064e3b">Analyzer A</text>
+    <text x="590" y="70" text-anchor="middle" font-size="11" fill="#065f46">required_topics() = ["x"]</text>
+  </g>
+  <g>
+    <rect x="490" y="128" width="200" height="54" rx="8" fill="#ecfdf5" stroke="#059669" stroke-width="1.5"/>
+    <text x="590" y="150" text-anchor="middle" font-weight="600" fill="#064e3b">Analyzer B</text>
+    <text x="590" y="168" text-anchor="middle" font-size="11" fill="#065f46">required_topics() = ["y","z"]</text>
+  </g>
+  <g>
+    <rect x="490" y="226" width="200" height="54" rx="8" fill="#ecfdf5" stroke="#059669" stroke-width="1.5"/>
+    <text x="590" y="248" text-anchor="middle" font-weight="600" fill="#064e3b">Analyzer C</text>
+    <text x="590" y="266" text-anchor="middle" font-size="11" fill="#065f46">on_message(DataMessage)</text>
+  </g>
+
+  <!-- Collector / finish -->
+  <rect x="730" y="120" width="150" height="70" rx="10" fill="#fef3c7" stroke="#b45309" stroke-width="1.5"/>
+  <text x="805" y="148" text-anchor="middle" font-weight="600" fill="#78350f">finish()</text>
+  <text x="805" y="168" text-anchor="middle" font-size="12" fill="#78350f">Vec&lt;Diagnostic&gt;</text>
+
+  <!-- Arrows -->
+  <line x1="160" y1="155" x2="200" y2="155" stroke="#334155" stroke-width="1.8" marker-end="url(#arrow)"/>
+  <line x1="370" y1="155" x2="418" y2="155" stroke="#334155" stroke-width="1.8" marker-end="url(#arrow)"/>
+  <line x1="442" y1="150" x2="490" y2="57" stroke="#334155" stroke-width="1.8" marker-end="url(#arrow)"/>
+  <line x1="442" y1="155" x2="490" y2="155" stroke="#334155" stroke-width="1.8" marker-end="url(#arrow)"/>
+  <line x1="442" y1="160" x2="490" y2="253" stroke="#334155" stroke-width="1.8" marker-end="url(#arrow)"/>
+  <line x1="690" y1="57" x2="735" y2="140" stroke="#334155" stroke-width="1.8" marker-end="url(#arrow)"/>
+  <line x1="690" y1="155" x2="730" y2="155" stroke="#334155" stroke-width="1.8" marker-end="url(#arrow)"/>
+  <line x1="690" y1="253" x2="735" y2="170" stroke="#334155" stroke-width="1.8" marker-end="url(#arrow)"/>
+
+  <!-- Footer note -->
+  <text x="450" y="305" text-anchor="middle" font-size="12" fill="#64748b">Each message is delivered once, in order, only to analyzers whose required_topics() match.</text>
+</svg>

--- a/crates/converter/src/diagnostics/docs/workflow.svg
+++ b/crates/converter/src/diagnostics/docs/workflow.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 220" font-family="-apple-system, Segoe UI, Helvetica, Arial, sans-serif" font-size="13">
+  <defs>
+    <marker id="arrow2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#334155"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="960" height="220" fill="#ffffff"/>
+
+  <!-- Step 1 -->
+  <g>
+    <rect x="20" y="50" width="160" height="110" rx="12" fill="#eff6ff" stroke="#1d4ed8" stroke-width="1.5"/>
+    <circle cx="45" cy="75" r="16" fill="#1d4ed8"/>
+    <text x="45" y="80" text-anchor="middle" fill="#ffffff" font-weight="700">1</text>
+    <text x="100" y="105" text-anchor="middle" font-weight="600" fill="#1e3a8a">Evidence variant</text>
+    <text x="100" y="125" text-anchor="middle" font-size="11" fill="#1e40af">add to mod.rs</text>
+    <text x="100" y="142" text-anchor="middle" font-size="11" fill="#1e40af">typed, not freeform</text>
+  </g>
+
+  <!-- Step 2 -->
+  <g>
+    <rect x="210" y="50" width="160" height="110" rx="12" fill="#ecfeff" stroke="#0891b2" stroke-width="1.5"/>
+    <circle cx="235" cy="75" r="16" fill="#0891b2"/>
+    <text x="235" y="80" text-anchor="middle" fill="#ffffff" font-weight="700">2</text>
+    <text x="290" y="105" text-anchor="middle" font-weight="600" fill="#164e63">Analyzer file</text>
+    <text x="290" y="125" text-anchor="middle" font-size="11" fill="#155e75">impl Analyzer trait</text>
+    <text x="290" y="142" text-anchor="middle" font-size="11" fill="#155e75">in diagnostics/</text>
+  </g>
+
+  <!-- Step 3 -->
+  <g>
+    <rect x="400" y="50" width="160" height="110" rx="12" fill="#ecfdf5" stroke="#059669" stroke-width="1.5"/>
+    <circle cx="425" cy="75" r="16" fill="#059669"/>
+    <text x="425" y="80" text-anchor="middle" fill="#ffffff" font-weight="700">3</text>
+    <text x="480" y="105" text-anchor="middle" font-weight="600" fill="#064e3b">Register</text>
+    <text x="480" y="125" text-anchor="middle" font-size="11" fill="#065f46">create_analyzers()</text>
+    <text x="480" y="142" text-anchor="middle" font-size="11" fill="#065f46">in mod.rs</text>
+  </g>
+
+  <!-- Step 4 -->
+  <g>
+    <rect x="590" y="50" width="160" height="110" rx="12" fill="#fefce8" stroke="#ca8a04" stroke-width="1.5"/>
+    <circle cx="615" cy="75" r="16" fill="#ca8a04"/>
+    <text x="615" y="80" text-anchor="middle" fill="#ffffff" font-weight="700">4</text>
+    <text x="670" y="102" text-anchor="middle" font-weight="600" fill="#713f12">Tests</text>
+    <text x="670" y="120" text-anchor="middle" font-size="11" fill="#854d0e">no-false-positives,</text>
+    <text x="670" y="134" text-anchor="middle" font-size="11" fill="#854d0e">fixture, snapshot,</text>
+    <text x="670" y="148" text-anchor="middle" font-size="11" fill="#854d0e">missing fields</text>
+  </g>
+
+  <!-- Step 5 -->
+  <g>
+    <rect x="780" y="50" width="160" height="110" rx="12" fill="#fef2f2" stroke="#dc2626" stroke-width="1.5"/>
+    <circle cx="805" cy="75" r="16" fill="#dc2626"/>
+    <text x="805" y="80" text-anchor="middle" fill="#ffffff" font-weight="700">5</text>
+    <text x="860" y="102" text-anchor="middle" font-weight="600" fill="#7f1d1d">CI gates</text>
+    <text x="860" y="120" text-anchor="middle" font-size="11" fill="#991b1b">check-analyzer.sh,</text>
+    <text x="860" y="134" text-anchor="middle" font-size="11" fill="#991b1b">cargo test,</text>
+    <text x="860" y="148" text-anchor="middle" font-size="11" fill="#991b1b">cargo bench</text>
+  </g>
+
+  <!-- Connectors -->
+  <line x1="180" y1="105" x2="210" y2="105" stroke="#334155" stroke-width="1.8" marker-end="url(#arrow2)"/>
+  <line x1="370" y1="105" x2="400" y2="105" stroke="#334155" stroke-width="1.8" marker-end="url(#arrow2)"/>
+  <line x1="560" y1="105" x2="590" y2="105" stroke="#334155" stroke-width="1.8" marker-end="url(#arrow2)"/>
+  <line x1="750" y1="105" x2="780" y2="105" stroke="#334155" stroke-width="1.8" marker-end="url(#arrow2)"/>
+
+  <text x="480" y="30" text-anchor="middle" font-weight="600" fill="#0f172a" font-size="14">Adding an analyzer — 5 steps</text>
+  <text x="480" y="195" text-anchor="middle" font-size="12" fill="#64748b">Reference implementation: rc_loss.rs</text>
+</svg>


### PR DESCRIPTION
Adds a contributor guide at `crates/converter/src/diagnostics/CONTRIBUTING.md` that walks a new contributor through adding a diagnostic analyzer: defining an `Evidence` variant, creating the analyzer file, registering it in `create_analyzers()`, writing the tests the CI gate requires, and running the same checks locally. It points at [`rc_loss.rs`](./crates/converter/src/diagnostics/rc_loss.rs) as the reference implementation and calls out the common first-time mistakes (redefining the trait, wrong file location, returning freeform strings instead of typed `Diagnostic`, adding heavy ML deps without a perf conversation).

Two SVG diagrams live in `crates/converter/src/diagnostics/docs/`:

- `workflow.svg` — the five-step contributor flow as a numbered chain.
- `pipeline.svg` — the runtime architecture (ULog stream → streaming `analyze()` pass → topic dispatch → analyzers → `finish()` → `Vec<Diagnostic>`), which makes the single-pass streaming model visually obvious.

No code changes, no behavior changes. Draft so we can preview the rendered SVGs before merging.