### PR TITLE
feat: typed output descriptors for diagnostic analyzers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /data
 /.claude
 /node_modules
+*.code-workspace
+*.db
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,9 +1578,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",

--- a/README.md
+++ b/README.md
@@ -548,6 +548,10 @@ See the full contributor guide at [`crates/converter/src/diagnostics/CONTRIBUTIN
 
 CI (`diagnostics.yml`) validates the pattern automatically on PRs that touch the diagnostics directory. Run `scripts/ci/check-analyzer.sh` locally to verify before pushing.
 
+### Output Descriptors
+
+Each analyzer implements `output_descriptor()` to declare the typed semantics of its evidence fields (`FieldUnit::Volts`, `FieldUnit::Pwm`, etc.). These descriptors are embedded on each `Diagnostic` and baked into `metadata.json` at ingest time — no separate API call, no late-binding. Each diagnostic also carries an `AnomalyKind` (Point or Region) and a `PlotAnchor` (topic + field) for precise plot overlay. See the [Output Descriptor](crates/converter/src/diagnostics/CONTRIBUTING.md#output-descriptor) section of the contributor guide for details.
+
 ## For Researchers
 
 There are two paths for working with flight log data, depending on your tools and workflow.

--- a/crates/converter/src/diagnostics/CONTRIBUTING.md
+++ b/crates/converter/src/diagnostics/CONTRIBUTING.md
@@ -110,9 +110,8 @@ impl Analyzer for YourAnalyzer {
                         id: "your_analyzer".to_string(),
                         summary: format!("Z-axis vibration {az:.1} m/s² at {:.1}s", ts as f64 / 1e6),
                         severity: Severity::Warning,
-                        kind: AnomalyKind::Point,       // or Region for windowed anomalies
+                        kind: AnomalyKind::Point,
                         timestamp_us: ts,
-                        end_timestamp_us: None,          // Some(end_ts) for Region
                         anchor: PlotAnchor::new("sensor_combined", "accelerometer_m_s2[2]"),
                         descriptor: self.output_descriptor(),
                         evidence: Evidence::ZAxisVibrationAnomaly {
@@ -151,7 +150,7 @@ impl Analyzer for YourAnalyzer {
 
 ### Diagnostic fields
 
-- **`kind: AnomalyKind`** — `Point` (single instant) or `Region` (time window with `end_timestamp_us`). Set explicitly per diagnostic, not per analyzer.
+- **`kind: AnomalyKind`** — `Point` (single instant) or `Region { end_timestamp_us }` (time window). The end timestamp lives inside the variant — a point can't have one, a region must.
 - **`anchor: PlotAnchor`** — the specific `(topic, field)` where the anomaly should be plotted. Motor 4 failing anchors to `("actuator_outputs", "output[4]")`, not just the topic generically. Set at emit time since the analyzer knows the exact field.
 - **`descriptor: OutputDescriptor`** — typed field semantics embedded on each diagnostic. Built via the builder API (see below).
 
@@ -186,7 +185,7 @@ Available `FieldUnit` variants:
 
 Each `Diagnostic` carries:
 
-- **`kind: AnomalyKind`** — `Point` (single instant) or `Region` (time window with `end_timestamp_us`). Set explicitly per diagnostic, not per analyzer.
+- **`kind: AnomalyKind`** — `Point` (single instant) or `Region { end_timestamp_us }` (time window). The end timestamp lives inside the variant — a point can't have one, a region must.
 - **`anchor: PlotAnchor`** — the specific `(topic, field)` where the anomaly should be plotted. Motor 4 failing anchors to `("actuator_outputs", "output[4]")`, not just the topic generically. Set at emit time since the analyzer knows the exact field.
 
 ## Step 3: Register it

--- a/crates/converter/src/diagnostics/CONTRIBUTING.md
+++ b/crates/converter/src/diagnostics/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Key properties to keep in mind when designing an analyzer:
 
 ## Step 1: Add an `Evidence` variant
 
-Every analyzer emits typed, structured evidence — not freeform strings or maps. The frontend matches on `evidence.type` and renders a specific UI for each variant. Changing an existing variant's fields is a breaking schema change, so pick field names carefully the first time.
+Every analyzer emits typed, structured evidence — not freeform strings or maps. Changing an existing variant's fields is a breaking schema change, so pick field names carefully the first time.
 
 Edit [`mod.rs`](./mod.rs) and add your variant:
 
@@ -37,9 +37,21 @@ pub enum Evidence {
 
 Also bump `ANALYSIS_VERSION` in the same file when your analyzer is ready to ship. That tells the reprocessing pipeline historical logs need a re-scan.
 
-## Step 2: Create the analyzer file
+## Step 2: Create the analyzer
 
-Create `crates/converter/src/diagnostics/your_analyzer.rs`. Minimal skeleton:
+Each analyzer is a flat `.rs` file in the `diagnostics/` directory:
+
+```
+diagnostics/
+├── mod.rs                  # Core types, trait, factory
+├── testing.rs              # Test utilities (MessageBuilder, etc.)
+├── your_analyzer.rs        # ← your analyzer
+├── battery_brownout.rs
+├── ekf_failure.rs
+└── ...
+```
+
+Create `crates/converter/src/diagnostics/your_analyzer.rs`:
 
 ```rust
 //! Short description of what this analyzer detects and how.
@@ -47,13 +59,15 @@ Create `crates/converter/src/diagnostics/your_analyzer.rs`. Minimal skeleton:
 //! Topics consumed, thresholds used, and any known limitations or fixture gaps
 //! (use SKIP_FIXTURE: <reason> if no real-world log exists yet).
 
-use super::{parse_field, Analyzer, Diagnostic, Evidence, Severity};
+use super::{
+    parse_field, AnomalyKind, Analyzer, Diagnostic, Evidence, FieldUnit,
+    OutputDescriptor, PlotAnchor, Severity,
+};
 use px4_ulog::stream_parser::model::DataMessage;
 
 const SOME_THRESHOLD: f32 = 2.5;
 
 pub struct YourAnalyzer {
-    // Per-flight state. Reset per log.
     detections: Vec<Diagnostic>,
 }
 
@@ -90,8 +104,25 @@ impl Analyzer for YourAnalyzer {
                 let Some(az) = parse_field::<f32>(data, "accelerometer_m_s2[2]") else {
                     return;
                 };
-                // ... update state, maybe push to self.detections ...
-                let _ = (ts, az);
+                // ... detect anomaly, emit Diagnostic ...
+                if az > SOME_THRESHOLD {
+                    self.detections.push(Diagnostic {
+                        id: "your_analyzer".to_string(),
+                        summary: format!("Z-axis vibration {az:.1} m/s² at {:.1}s", ts as f64 / 1e6),
+                        severity: Severity::Warning,
+                        kind: AnomalyKind::Point,       // or Region for windowed anomalies
+                        timestamp_us: ts,
+                        end_timestamp_us: None,          // Some(end_ts) for Region
+                        anchor: PlotAnchor::new("sensor_combined", "accelerometer_m_s2[2]"),
+                        descriptor: self.output_descriptor(),
+                        evidence: Evidence::ZAxisVibrationAnomaly {
+                            score: az,
+                            peak_accel_m_s2: az,
+                            window_start_us: ts,
+                            window_end_us: ts,
+                        },
+                    });
+                }
             }
             _ => {}
         }
@@ -100,15 +131,63 @@ impl Analyzer for YourAnalyzer {
     fn finish(self: Box<Self>) -> Vec<Diagnostic> {
         self.detections
     }
+
+    fn output_descriptor(&self) -> OutputDescriptor {
+        OutputDescriptor::new()
+            .field("score", FieldUnit::Ratio)
+            .field("peak_accel_m_s2", FieldUnit::Meters)  // m/s² — closest typed unit
+            .field("window_start_us", FieldUnit::Microseconds)
+            .field("window_end_us", FieldUnit::Microseconds)
+    }
 }
 ```
 
-Notes on the trait methods:
+### Trait methods
 
 - **`id()`** is the stable machine identifier stored in the database and exposed via the API's `?diagnostic=` filter. Don't change it after release.
 - **`required_topics()`** must match the exact ULog topic names. Typos mean your analyzer silently never runs.
 - **`on_message()`** must not panic and must handle missing fields gracefully — use `parse_field::<T>()`, which returns `Option<T>`, never unwrap.
 - **`finish()`** takes `Box<Self>` (the pipeline owns the analyzers). Move your accumulated detections out and return them.
+
+### Diagnostic fields
+
+- **`kind: AnomalyKind`** — `Point` (single instant) or `Region` (time window with `end_timestamp_us`). Set explicitly per diagnostic, not per analyzer.
+- **`anchor: PlotAnchor`** — the specific `(topic, field)` where the anomaly should be plotted. Motor 4 failing anchors to `("actuator_outputs", "output[4]")`, not just the topic generically. Set at emit time since the analyzer knows the exact field.
+- **`descriptor: OutputDescriptor`** — typed field semantics embedded on each diagnostic. Built via the builder API (see below).
+
+### Output descriptor
+
+Every analyzer implements `output_descriptor()` to declare the typed semantics of its evidence fields. This is baked into `metadata.json` alongside the diagnostics at ingest time — no separate API call, no late-binding.
+
+Use the builder API:
+
+```rust
+OutputDescriptor::new()
+    .field("voltage_v", FieldUnit::Volts)
+    .field("current_a", FieldUnit::Amps)
+    .field("flight_mode", FieldUnit::Label)
+```
+
+Available `FieldUnit` variants:
+
+| Unit | Meaning |
+|---|---|
+| `Volts` | Voltage |
+| `Amps` | Current |
+| `Meters` | Distance |
+| `Microseconds` | Timestamp or duration in µs |
+| `Milliseconds` | Duration in ms |
+| `Pwm` | PWM output value |
+| `Ratio` | Dimensionless ratio |
+| `Count` | Integer count |
+| `Label` | Free-form string (flight mode, innovation name, etc.) |
+
+### Anomaly kind and plot anchor
+
+Each `Diagnostic` carries:
+
+- **`kind: AnomalyKind`** — `Point` (single instant) or `Region` (time window with `end_timestamp_us`). Set explicitly per diagnostic, not per analyzer.
+- **`anchor: PlotAnchor`** — the specific `(topic, field)` where the anomaly should be plotted. Motor 4 failing anchors to `("actuator_outputs", "output[4]")`, not just the topic generically. Set at emit time since the analyzer knows the exact field.
 
 ## Step 3: Register it
 
@@ -154,7 +233,7 @@ cargo test -p flight-review --lib diagnostics
 cargo bench -p flight-review --bench convert
 ```
 
-If `check-analyzer.sh` complains, it will tell you exactly which of the five criteria you missed. If the bench regresses past the budget, profile your `on_message` — the usual culprit is allocating or parsing the same field multiple times per message.
+If `check-analyzer.sh` complains, it will tell you exactly which criteria you missed. If the bench regresses past the budget, profile your `on_message` — the usual culprit is allocating or parsing the same field multiple times per message.
 
 ## Common first-time mistakes
 
@@ -164,6 +243,7 @@ If `check-analyzer.sh` complains, it will tell you exactly which of the five cri
 - **Assuming you get the whole log at once.** You don't. Design for streaming.
 - **Pulling in heavy ML dependencies without discussing the perf/memory budget first.** The converter is zero-ML today; open an issue before adding something like `extended-isolation-forest`, `smartcore`, etc. so we can agree on how the model is trained, shipped, and benchmarked.
 - **Skipping the real-world fixture.** Synthetic tests alone don't count toward the CI gate. Either ship a fixture or mark `SKIP_FIXTURE` with a reason.
+- **Using free-form strings for field metadata.** Use `FieldUnit` typed descriptors. No `"unit": "V"` strings — use `FieldUnit::Volts`.
 
 ## Questions
 

--- a/crates/converter/src/diagnostics/battery_brownout.rs
+++ b/crates/converter/src/diagnostics/battery_brownout.rs
@@ -122,7 +122,6 @@ impl Analyzer for BatteryBrownoutAnalyzer {
                         severity: Severity::Critical,
                         kind: AnomalyKind::Point,
                         timestamp_us: ts,
-                        end_timestamp_us: None,
                         anchor: PlotAnchor::new("battery_status", "voltage_v"),
                         descriptor: self.output_descriptor(),
                         evidence: Evidence::BatteryBrownout {

--- a/crates/converter/src/diagnostics/battery_brownout.rs
+++ b/crates/converter/src/diagnostics/battery_brownout.rs
@@ -4,7 +4,10 @@
 //! cell count from initial voltage and flags when voltage drops below
 //! critical threshold per cell.
 
-use super::{parse_field, Analyzer, Diagnostic, Evidence, Severity};
+use super::{
+    parse_field, AnomalyKind, Analyzer, Diagnostic, Evidence, FieldUnit, OutputDescriptor,
+    PlotAnchor, Severity,
+};
 use px4_ulog::stream_parser::model::DataMessage;
 
 /// Per-cell critical voltage threshold (V).
@@ -117,8 +120,11 @@ impl Analyzer for BatteryBrownoutAnalyzer {
                             self.cell_count.unwrap_or(0),
                         ),
                         severity: Severity::Critical,
+                        kind: AnomalyKind::Point,
                         timestamp_us: ts,
                         end_timestamp_us: None,
+                        anchor: PlotAnchor::new("battery_status", "voltage_v"),
+                        descriptor: self.output_descriptor(),
                         evidence: Evidence::BatteryBrownout {
                             voltage_v: voltage,
                             critical_threshold_v: self.critical_threshold_v,
@@ -133,6 +139,13 @@ impl Analyzer for BatteryBrownoutAnalyzer {
 
     fn finish(self: Box<Self>) -> Vec<Diagnostic> {
         self.detections
+    }
+
+    fn output_descriptor(&self) -> OutputDescriptor {
+        OutputDescriptor::new()
+            .field("voltage_v", FieldUnit::Volts)
+            .field("critical_threshold_v", FieldUnit::Volts)
+            .field("current_a", FieldUnit::Amps)
     }
 }
 

--- a/crates/converter/src/diagnostics/ekf_failure.rs
+++ b/crates/converter/src/diagnostics/ekf_failure.rs
@@ -69,9 +69,8 @@ impl InnovationTracker {
                         start as f64 / 1_000_000.0,
                     ),
                     severity: Severity::Critical,
-                    kind: AnomalyKind::Region,
+                    kind: AnomalyKind::Region { end_timestamp_us: ts },
                     timestamp_us: start,
-                    end_timestamp_us: Some(ts),
                     anchor: PlotAnchor::new("estimator_status", self.field_name),
                     descriptor: descriptor.clone(),
                     evidence: Evidence::EkfFailure {
@@ -91,9 +90,8 @@ impl InnovationTracker {
                         start as f64 / 1_000_000.0,
                     ),
                     severity: Severity::Warning,
-                    kind: AnomalyKind::Region,
+                    kind: AnomalyKind::Region { end_timestamp_us: ts },
                     timestamp_us: start,
-                    end_timestamp_us: Some(ts),
                     anchor: PlotAnchor::new("estimator_status", self.field_name),
                     descriptor: descriptor.clone(),
                     evidence: Evidence::EkfFailure {

--- a/crates/converter/src/diagnostics/ekf_failure.rs
+++ b/crates/converter/src/diagnostics/ekf_failure.rs
@@ -5,7 +5,10 @@
 //! EKF is failing to converge and the position/velocity estimates are
 //! unreliable.
 
-use super::{parse_field, Analyzer, Diagnostic, Evidence, Severity};
+use super::{
+    parse_field, AnomalyKind, Analyzer, Diagnostic, Evidence, FieldUnit, OutputDescriptor,
+    PlotAnchor, Severity,
+};
 use px4_ulog::stream_parser::model::DataMessage;
 
 /// Test ratio threshold — above this the EKF innovation is failing.
@@ -35,7 +38,13 @@ impl InnovationTracker {
         }
     }
 
-    fn update(&mut self, ts: u64, ratio: f32, detections: &mut Vec<Diagnostic>) {
+    fn update(
+        &mut self,
+        ts: u64,
+        ratio: f32,
+        descriptor: &OutputDescriptor,
+        detections: &mut Vec<Diagnostic>,
+    ) {
         if !ratio.is_finite() {
             return;
         }
@@ -60,8 +69,11 @@ impl InnovationTracker {
                         start as f64 / 1_000_000.0,
                     ),
                     severity: Severity::Critical,
+                    kind: AnomalyKind::Region,
                     timestamp_us: start,
                     end_timestamp_us: Some(ts),
+                    anchor: PlotAnchor::new("estimator_status", self.field_name),
+                    descriptor: descriptor.clone(),
                     evidence: Evidence::EkfFailure {
                         innovation: self.name.to_string(),
                         test_ratio: ratio,
@@ -79,8 +91,11 @@ impl InnovationTracker {
                         start as f64 / 1_000_000.0,
                     ),
                     severity: Severity::Warning,
+                    kind: AnomalyKind::Region,
                     timestamp_us: start,
                     end_timestamp_us: Some(ts),
+                    anchor: PlotAnchor::new("estimator_status", self.field_name),
+                    descriptor: descriptor.clone(),
                     evidence: Evidence::EkfFailure {
                         innovation: self.name.to_string(),
                         test_ratio: ratio,
@@ -147,15 +162,23 @@ impl Analyzer for EkfFailureAnalyzer {
             .map(|tf| tf.parse_timestamp(data.data))
             .unwrap_or(0);
 
+        let descriptor = self.output_descriptor();
         for tracker in &mut self.trackers {
             if let Some(ratio) = parse_field::<f32>(data, tracker.field_name) {
-                tracker.update(ts, ratio, &mut self.detections);
+                tracker.update(ts, ratio, &descriptor, &mut self.detections);
             }
         }
     }
 
     fn finish(self: Box<Self>) -> Vec<Diagnostic> {
         self.detections
+    }
+
+    fn output_descriptor(&self) -> OutputDescriptor {
+        OutputDescriptor::new()
+            .field("innovation", FieldUnit::Label)
+            .field("test_ratio", FieldUnit::Ratio)
+            .field("threshold", FieldUnit::Ratio)
     }
 }
 

--- a/crates/converter/src/diagnostics/ekf_selector_whipsaw.rs
+++ b/crates/converter/src/diagnostics/ekf_selector_whipsaw.rs
@@ -13,7 +13,10 @@
 //! - Combined with high `combined_test_ratio` on an instance that the
 //!   selector switches to (indicates switching to a degraded instance)
 
-use super::{parse_field, Analyzer, Diagnostic, Evidence, Severity};
+use super::{
+    parse_field, AnomalyKind, Analyzer, Diagnostic, Evidence, FieldUnit, OutputDescriptor,
+    PlotAnchor, Severity,
+};
 use px4_ulog::stream_parser::model::DataMessage;
 use std::collections::VecDeque;
 
@@ -218,8 +221,13 @@ impl Analyzer for EkfSelectorWhipsawAnalyzer {
                 id: "ekf_selector_whipsaw".to_string(),
                 summary,
                 severity,
+                kind: AnomalyKind::Region { end_timestamp_us: ts },
                 timestamp_us: window_start,
-                end_timestamp_us: Some(ts),
+                anchor: PlotAnchor::new(
+                    "estimator_selector_status",
+                    "instance_changed_count",
+                ),
+                descriptor: self.output_descriptor(),
                 evidence: Evidence::EkfSelectorWhipsaw {
                     switch_count: switches_in_window,
                     window_duration_ms: window_duration_us / 1_000,
@@ -233,6 +241,15 @@ impl Analyzer for EkfSelectorWhipsawAnalyzer {
 
     fn finish(self: Box<Self>) -> Vec<Diagnostic> {
         self.detections
+    }
+
+    fn output_descriptor(&self) -> OutputDescriptor {
+        OutputDescriptor::new()
+            .field("switch_count", FieldUnit::Count)
+            .field("window_duration_ms", FieldUnit::Milliseconds)
+            .field("avg_switch_interval_ms", FieldUnit::Milliseconds)
+            .field("switched_to_degraded", FieldUnit::Label)
+            .field("primary_instance_test_ratio", FieldUnit::Ratio)
     }
 }
 

--- a/crates/converter/src/diagnostics/gps_interference.rs
+++ b/crates/converter/src/diagnostics/gps_interference.rs
@@ -165,7 +165,6 @@ impl Analyzer for GpsInterferenceAnalyzer {
                 severity,
                 kind: AnomalyKind::Point,
                 timestamp_us: ts,
-                end_timestamp_us: None,
                 anchor: PlotAnchor::new("vehicle_gps_position", "eph"),
                 descriptor: self.output_descriptor(),
                 evidence: Evidence::GpsInterference {

--- a/crates/converter/src/diagnostics/gps_interference.rs
+++ b/crates/converter/src/diagnostics/gps_interference.rs
@@ -5,7 +5,10 @@
 //! - EPV (vertical position error) spikes above threshold
 //! - Satellite count drops significantly below baseline
 
-use super::{parse_field, Analyzer, Diagnostic, Evidence, Severity};
+use super::{
+    parse_field, AnomalyKind, Analyzer, Diagnostic, Evidence, FieldUnit, OutputDescriptor,
+    PlotAnchor, Severity,
+};
 use px4_ulog::stream_parser::model::DataMessage;
 
 /// Number of samples to establish baseline.
@@ -160,8 +163,11 @@ impl Analyzer for GpsInterferenceAnalyzer {
                     reasons.join(", ")
                 ),
                 severity,
+                kind: AnomalyKind::Point,
                 timestamp_us: ts,
                 end_timestamp_us: None,
+                anchor: PlotAnchor::new("vehicle_gps_position", "eph"),
+                descriptor: self.output_descriptor(),
                 evidence: Evidence::GpsInterference {
                     eph_m: current_eph,
                     epv_m: current_epv,
@@ -174,6 +180,14 @@ impl Analyzer for GpsInterferenceAnalyzer {
 
     fn finish(self: Box<Self>) -> Vec<Diagnostic> {
         self.detections
+    }
+
+    fn output_descriptor(&self) -> OutputDescriptor {
+        OutputDescriptor::new()
+            .field("eph_m", FieldUnit::Meters)
+            .field("epv_m", FieldUnit::Meters)
+            .field("num_satellites", FieldUnit::Count)
+            .field("noise_level", FieldUnit::Ratio)
     }
 }
 

--- a/crates/converter/src/diagnostics/mod.rs
+++ b/crates/converter/src/diagnostics/mod.rs
@@ -29,8 +29,6 @@ pub mod testing;
 /// reprocessing of historical logs.
 pub const ANALYSIS_VERSION: u32 = 2;
 
-// ── Output descriptor types ───────────────────────────────────────────
-
 /// Whether a diagnostic marks an instant or spans a time window.
 ///
 /// `end_timestamp_us` lives on `Region` — a point cannot have an end,
@@ -118,8 +116,6 @@ impl Default for OutputDescriptor {
         Self::new()
     }
 }
-
-// ── Core diagnostic types ─────────────────────────────────────────────
 
 /// Severity of a detected anomaly.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/converter/src/diagnostics/mod.rs
+++ b/crates/converter/src/diagnostics/mod.rs
@@ -286,4 +286,3 @@ pub fn create_analyzers_filtered(ids: &[String]) -> Result<Vec<Box<dyn Analyzer>
     }
     Ok(selected)
 }
-

--- a/crates/converter/src/diagnostics/mod.rs
+++ b/crates/converter/src/diagnostics/mod.rs
@@ -32,13 +32,19 @@ pub const ANALYSIS_VERSION: u32 = 2;
 // ── Output descriptor types ───────────────────────────────────────────
 
 /// Whether a diagnostic marks an instant or spans a time window.
+///
+/// `end_timestamp_us` lives on `Region` — a point cannot have an end,
+/// and a region must. Invalid states are unrepresentable.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AnomalyKind {
     /// Single point in time (e.g., battery brownout, motor drop-to-zero).
     Point,
-    /// Spans a time window with start and end (e.g., EKF failure, RC loss).
-    Region,
+    /// Spans a time window (e.g., EKF failure, RC loss).
+    Region {
+        /// End timestamp (microseconds) of the anomaly window.
+        end_timestamp_us: u64,
+    },
 }
 
 /// Where on a plot this specific anomaly should be anchored.
@@ -197,11 +203,10 @@ pub struct Diagnostic {
     /// Severity classification.
     pub severity: Severity,
     /// Whether this is a point-in-time or a region spanning a window.
+    /// For regions, carries `end_timestamp_us` inside the variant.
     pub kind: AnomalyKind,
     /// Timestamp (microseconds) where the anomaly was first detected.
     pub timestamp_us: u64,
-    /// End timestamp for Region anomalies; None for Point.
-    pub end_timestamp_us: Option<u64>,
     /// Where on a plot this anomaly should be anchored: (topic, field).
     pub anchor: PlotAnchor,
     /// Describes how to interpret the evidence fields (types, units).

--- a/crates/converter/src/diagnostics/mod.rs
+++ b/crates/converter/src/diagnostics/mod.rs
@@ -2,16 +2,16 @@
 //!
 //! Each analyzer implements the [`Analyzer`] trait, declares the ULog topics it
 //! needs, receives messages during the existing `analyze()` streaming pass, and
-//! emits [`Diagnostic`] structs with severity, timestamps, and typed evidence.
+//! emits [`Diagnostic`] structs with severity, timestamps, typed evidence, and
+//! an [`OutputDescriptor`] that describes how to interpret the evidence fields.
 //!
 //! # Adding a new analyzer
 //!
 //! 1. Create `crates/converter/src/diagnostics/your_analyzer.rs`
 //! 2. Add a new variant to [`Evidence`] for your diagnostic type
-//! 3. Implement the [`Analyzer`] trait
+//! 3. Implement the [`Analyzer`] trait (including `output_descriptor()`)
 //! 4. Register it in [`create_analyzers()`]
 //! 5. Add tests following the required pattern in [`testing`]
-//! 6. Run `cargo bench` and include results in your PR
 
 use px4_ulog::stream_parser::model::{DataMessage, ParseableFieldType};
 use serde::{Deserialize, Serialize};
@@ -29,6 +29,92 @@ pub mod testing;
 /// reprocessing of historical logs.
 pub const ANALYSIS_VERSION: u32 = 2;
 
+// ── Output descriptor types ───────────────────────────────────────────
+
+/// Whether a diagnostic marks an instant or spans a time window.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnomalyKind {
+    /// Single point in time (e.g., battery brownout, motor drop-to-zero).
+    Point,
+    /// Spans a time window with start and end (e.g., EKF failure, RC loss).
+    Region,
+}
+
+/// Where on a plot this specific anomaly should be anchored.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlotAnchor {
+    pub topic: String,
+    pub field: String,
+}
+
+impl PlotAnchor {
+    pub fn new(topic: &str, field: &str) -> Self {
+        Self {
+            topic: topic.to_string(),
+            field: field.to_string(),
+        }
+    }
+}
+
+/// Typed semantic for an evidence field value.
+///
+/// Used instead of free-form unit/format strings so invalid descriptors
+/// are caught at compile time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FieldUnit {
+    Volts,
+    Amps,
+    Meters,
+    Microseconds,
+    Milliseconds,
+    Pwm,
+    Ratio,
+    Count,
+    /// Free-form string field (flight mode, innovation name, etc.).
+    Label,
+}
+
+/// Descriptor for a single evidence field.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FieldDescriptor {
+    pub name: String,
+    pub unit: FieldUnit,
+}
+
+/// Describes how to interpret a diagnostic's evidence fields.
+///
+/// Built via typed constructors — not hand-written JSON.
+/// Embedded on each [`Diagnostic`], self-contained and pre-joined.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutputDescriptor {
+    pub fields: Vec<FieldDescriptor>,
+}
+
+impl OutputDescriptor {
+    pub fn new() -> Self {
+        Self { fields: vec![] }
+    }
+
+    /// Declare an evidence field with a typed unit.
+    pub fn field(mut self, name: &str, unit: FieldUnit) -> Self {
+        self.fields.push(FieldDescriptor {
+            name: name.to_string(),
+            unit,
+        });
+        self
+    }
+}
+
+impl Default for OutputDescriptor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Core diagnostic types ─────────────────────────────────────────────
+
 /// Severity of a detected anomaly.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -41,20 +127,27 @@ pub enum Severity {
     Critical,
 }
 
+/// Motor failure mode — typed discriminant replacing free-form string.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MotorFailureMode {
+    DropToZero,
+    LockedAtMax,
+}
+
 /// Typed evidence for each diagnostic kind.
 ///
-/// Every analyzer returns a specific variant — not a freeform map. The frontend
-/// matches on `evidence.type` and renders structured UI for each diagnostic.
-/// Adding a new analyzer means adding a new variant here; changing an existing
-/// variant's fields is a breaking change requiring a version bump and backfill.
+/// Every analyzer returns a specific variant — not a freeform map.
+/// Adding a new analyzer means adding a new variant here; changing an
+/// existing variant's fields is a breaking change requiring a version
+/// bump and snapshot update.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum Evidence {
     MotorFailure {
         motor_index: u8,
         pwm_value: f32,
-        /// "drop_to_zero" or "locked_at_max"
-        failure_mode: String,
+        mode: MotorFailureMode,
         flight_mode: String,
     },
     GpsInterference {
@@ -94,7 +187,7 @@ pub enum Evidence {
     },
 }
 
-/// A single detected anomaly with typed evidence.
+/// A single detected anomaly with typed evidence and output descriptor.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Diagnostic {
     /// Machine-readable identifier, e.g. "motor_failure", "gps_interference".
@@ -103,10 +196,16 @@ pub struct Diagnostic {
     pub summary: String,
     /// Severity classification.
     pub severity: Severity,
+    /// Whether this is a point-in-time or a region spanning a window.
+    pub kind: AnomalyKind,
     /// Timestamp (microseconds) where the anomaly was first detected.
     pub timestamp_us: u64,
-    /// Optional end timestamp if the anomaly spans a window.
+    /// End timestamp for Region anomalies; None for Point.
     pub end_timestamp_us: Option<u64>,
+    /// Where on a plot this anomaly should be anchored: (topic, field).
+    pub anchor: PlotAnchor,
+    /// Describes how to interpret the evidence fields (types, units).
+    pub descriptor: OutputDescriptor,
     /// Typed, structured evidence specific to this diagnostic.
     pub evidence: Evidence,
 }
@@ -132,6 +231,9 @@ pub trait Analyzer {
 
     /// Called after the streaming pass completes. Return any detected anomalies.
     fn finish(self: Box<Self>) -> Vec<Diagnostic>;
+
+    /// Describes this analyzer's output shape — field names and typed units.
+    fn output_descriptor(&self) -> OutputDescriptor;
 }
 
 /// Parse a typed field from a DataMessage, returning None if the field is
@@ -144,7 +246,7 @@ pub fn parse_field<T: ParseableFieldType>(data: &DataMessage, name: &str) -> Opt
         .map(|p| p.parse(data.data))
 }
 
-/// Create all Phase 1 diagnostic analyzers.
+/// Create all diagnostic analyzers.
 pub fn create_analyzers() -> Vec<Box<dyn Analyzer>> {
     vec![
         Box::new(motor_failure::MotorFailureAnalyzer::new()),
@@ -179,3 +281,4 @@ pub fn create_analyzers_filtered(ids: &[String]) -> Result<Vec<Box<dyn Analyzer>
     }
     Ok(selected)
 }
+

--- a/crates/converter/src/diagnostics/motor_failure.rs
+++ b/crates/converter/src/diagnostics/motor_failure.rs
@@ -152,7 +152,6 @@ impl Analyzer for MotorFailureAnalyzer {
                             severity: Severity::Critical,
                             kind: AnomalyKind::Point,
                             timestamp_us: ts,
-                            end_timestamp_us: None,
                             anchor: PlotAnchor::new("actuator_outputs", &format!("output[{i}]")),
                             descriptor: self.output_descriptor(),
                             evidence: Evidence::MotorFailure {
@@ -181,9 +180,8 @@ impl Analyzer for MotorFailureAnalyzer {
                                     ts as f64 / 1_000_000.0,
                                 ),
                                 severity: Severity::Warning,
-                                kind: AnomalyKind::Region,
+                                kind: AnomalyKind::Region { end_timestamp_us: ts },
                                 timestamp_us: first_ts,
-                                end_timestamp_us: Some(ts),
                                 anchor: PlotAnchor::new("actuator_outputs", &format!("output[{i}]")),
                                 descriptor: self.output_descriptor(),
                                 evidence: Evidence::MotorFailure {

--- a/crates/converter/src/diagnostics/motor_failure.rs
+++ b/crates/converter/src/diagnostics/motor_failure.rs
@@ -8,7 +8,10 @@
 
 use std::collections::{HashSet, VecDeque};
 
-use super::{parse_field, Analyzer, Diagnostic, Evidence, Severity};
+use super::{
+    parse_field, AnomalyKind, Analyzer, Diagnostic, Evidence, FieldUnit, MotorFailureMode,
+    OutputDescriptor, PlotAnchor, Severity,
+};
 use crate::analysis::nav_state_name;
 use px4_ulog::stream_parser::model::DataMessage;
 
@@ -25,7 +28,7 @@ pub struct MotorFailureAnalyzer {
     motor_windows: Vec<VecDeque<(u64, f32)>>,
     detections: Vec<Diagnostic>,
     /// Track which (motor_index, failure_mode) pairs have already fired.
-    fired: HashSet<(u8, String)>,
+    fired: HashSet<(u8, MotorFailureMode)>,
     /// Track which motors have been active (non-zero output while armed).
     /// Unused channels stay at 0 and should not be flagged.
     motor_was_active: Vec<bool>,
@@ -136,8 +139,8 @@ impl Analyzer for MotorFailureAnalyzer {
 
                     // Check: PWM drop to zero — only if motor was previously active
                     let was_active = self.motor_was_active.get(i).copied().unwrap_or(false);
-                    if pwm == 0.0 && was_active && !self.fired.contains(&(motor_idx, "drop_to_zero".to_string())) {
-                        self.fired.insert((motor_idx, "drop_to_zero".to_string()));
+                    if pwm == 0.0 && was_active && !self.fired.contains(&(motor_idx, MotorFailureMode::DropToZero)) {
+                        self.fired.insert((motor_idx, MotorFailureMode::DropToZero));
                         self.detections.push(Diagnostic {
                             id: "motor_failure".to_string(),
                             summary: format!(
@@ -147,12 +150,15 @@ impl Analyzer for MotorFailureAnalyzer {
                                 self.current_flight_mode
                             ),
                             severity: Severity::Critical,
+                            kind: AnomalyKind::Point,
                             timestamp_us: ts,
                             end_timestamp_us: None,
+                            anchor: PlotAnchor::new("actuator_outputs", &format!("output[{i}]")),
+                            descriptor: self.output_descriptor(),
                             evidence: Evidence::MotorFailure {
                                 motor_index: motor_idx,
                                 pwm_value: pwm,
-                                failure_mode: "drop_to_zero".to_string(),
+                                mode: MotorFailureMode::DropToZero,
                                 flight_mode: self.current_flight_mode.clone(),
                             },
                         });
@@ -162,9 +168,9 @@ impl Analyzer for MotorFailureAnalyzer {
                     if let Some(window) = self.motor_windows.get(i) {
                         if window.len() == WINDOW_SIZE
                             && window.iter().all(|(_, p)| *p >= PWM_MAX_THRESHOLD)
-                            && !self.fired.contains(&(motor_idx, "locked_at_max".to_string()))
+                            && !self.fired.contains(&(motor_idx, MotorFailureMode::LockedAtMax))
                         {
-                            self.fired.insert((motor_idx, "locked_at_max".to_string()));
+                            self.fired.insert((motor_idx, MotorFailureMode::LockedAtMax));
                             let first_ts = window.front().map(|(t, _)| *t).unwrap_or(ts);
                             self.detections.push(Diagnostic {
                                 id: "motor_failure".to_string(),
@@ -175,12 +181,15 @@ impl Analyzer for MotorFailureAnalyzer {
                                     ts as f64 / 1_000_000.0,
                                 ),
                                 severity: Severity::Warning,
+                                kind: AnomalyKind::Region,
                                 timestamp_us: first_ts,
                                 end_timestamp_us: Some(ts),
+                                anchor: PlotAnchor::new("actuator_outputs", &format!("output[{i}]")),
+                                descriptor: self.output_descriptor(),
                                 evidence: Evidence::MotorFailure {
                                     motor_index: motor_idx,
                                     pwm_value: pwm,
-                                    failure_mode: "locked_at_max".to_string(),
+                                    mode: MotorFailureMode::LockedAtMax,
                                     flight_mode: self.current_flight_mode.clone(),
                                 },
                             });
@@ -194,6 +203,13 @@ impl Analyzer for MotorFailureAnalyzer {
 
     fn finish(self: Box<Self>) -> Vec<Diagnostic> {
         self.detections
+    }
+
+    fn output_descriptor(&self) -> OutputDescriptor {
+        OutputDescriptor::new()
+            .field("motor_index", FieldUnit::Count)
+            .field("pwm_value", FieldUnit::Pwm)
+            .field("flight_mode", FieldUnit::Label)
     }
 }
 
@@ -241,14 +257,17 @@ mod tests {
         let diags = Box::new(analyzer).finish();
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].severity, Severity::Critical);
+        assert_eq!(diags[0].kind, AnomalyKind::Point);
+        assert_eq!(diags[0].anchor.topic, "actuator_outputs");
+        assert_eq!(diags[0].anchor.field, "output[1]");
         match &diags[0].evidence {
             Evidence::MotorFailure {
                 motor_index,
-                failure_mode,
+                mode,
                 ..
             } => {
                 assert_eq!(*motor_index, 1);
-                assert_eq!(failure_mode, "drop_to_zero");
+                assert_eq!(*mode, MotorFailureMode::DropToZero);
             }
             _ => panic!("Expected MotorFailure evidence"),
         }

--- a/crates/converter/src/diagnostics/motor_failure.rs
+++ b/crates/converter/src/diagnostics/motor_failure.rs
@@ -208,6 +208,7 @@ impl Analyzer for MotorFailureAnalyzer {
             .field("motor_index", FieldUnit::Count)
             .field("pwm_value", FieldUnit::Pwm)
             .field("flight_mode", FieldUnit::Label)
+            .field("mode", FieldUnit::Label)
     }
 }
 

--- a/crates/converter/src/diagnostics/rc_loss.rs
+++ b/crates/converter/src/diagnostics/rc_loss.rs
@@ -7,7 +7,10 @@
 //! SKIP_FIXTURE: No known ULog in our corpus exhibits RC signal loss.
 //! Add a fixture when one becomes available.
 
-use super::{parse_field, Analyzer, Diagnostic, Evidence, Severity};
+use super::{
+    parse_field, AnomalyKind, Analyzer, Diagnostic, Evidence, FieldUnit, OutputDescriptor,
+    PlotAnchor, Severity,
+};
 use px4_ulog::stream_parser::model::DataMessage;
 
 /// Minimum loss duration (microseconds) to report.
@@ -61,8 +64,11 @@ impl RcLossAnalyzer {
                 start_us as f64 / 1_000_000.0,
             ),
             severity,
+            kind: AnomalyKind::Region,
             timestamp_us: start_us,
             end_timestamp_us: Some(end_us),
+            anchor: PlotAnchor::new("input_rc", "rc_lost"),
+            descriptor: self.output_descriptor(),
             evidence: Evidence::RcLoss {
                 last_signal_timestamp_us: self.last_signal_us,
                 signal_lost_duration_ms: duration_ms,
@@ -144,6 +150,12 @@ impl Analyzer for RcLossAnalyzer {
             }
         }
         self.detections
+    }
+
+    fn output_descriptor(&self) -> OutputDescriptor {
+        OutputDescriptor::new()
+            .field("last_signal_timestamp_us", FieldUnit::Microseconds)
+            .field("signal_lost_duration_ms", FieldUnit::Milliseconds)
     }
 }
 

--- a/crates/converter/src/diagnostics/rc_loss.rs
+++ b/crates/converter/src/diagnostics/rc_loss.rs
@@ -64,9 +64,8 @@ impl RcLossAnalyzer {
                 start_us as f64 / 1_000_000.0,
             ),
             severity,
-            kind: AnomalyKind::Region,
+            kind: AnomalyKind::Region { end_timestamp_us: end_us },
             timestamp_us: start_us,
-            end_timestamp_us: Some(end_us),
             anchor: PlotAnchor::new("input_rc", "rc_lost"),
             descriptor: self.output_descriptor(),
             evidence: Evidence::RcLoss {

--- a/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__battery_brownout__tests__detects_real_battery_brownout.snap
+++ b/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__battery_brownout__tests__detects_real_battery_brownout.snap
@@ -9,7 +9,6 @@ expression: diags
     "severity": "critical",
     "kind": "point",
     "timestamp_us": 158986930,
-    "end_timestamp_us": null,
     "anchor": {
       "topic": "battery_status",
       "field": "voltage_v"
@@ -43,7 +42,6 @@ expression: diags
     "severity": "critical",
     "kind": "point",
     "timestamp_us": 189186929,
-    "end_timestamp_us": null,
     "anchor": {
       "topic": "battery_status",
       "field": "voltage_v"
@@ -77,7 +75,6 @@ expression: diags
     "severity": "critical",
     "kind": "point",
     "timestamp_us": 219386927,
-    "end_timestamp_us": null,
     "anchor": {
       "topic": "battery_status",
       "field": "voltage_v"

--- a/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__battery_brownout__tests__detects_real_battery_brownout.snap
+++ b/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__battery_brownout__tests__detects_real_battery_brownout.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/converter/src/diagnostics/battery_brownout.rs
-assertion_line: 299
 expression: diags
 ---
 [
@@ -8,8 +7,29 @@ expression: diags
     "id": "battery_brownout",
     "summary": "Battery voltage 0.06V below critical threshold 3.3V at 159.0s (1S)",
     "severity": "critical",
+    "kind": "point",
     "timestamp_us": 158986930,
     "end_timestamp_us": null,
+    "anchor": {
+      "topic": "battery_status",
+      "field": "voltage_v"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "voltage_v",
+          "unit": "volts"
+        },
+        {
+          "name": "critical_threshold_v",
+          "unit": "volts"
+        },
+        {
+          "name": "current_a",
+          "unit": "amps"
+        }
+      ]
+    },
     "evidence": {
       "type": "BatteryBrownout",
       "voltage_v": 0.058330078,
@@ -21,8 +41,29 @@ expression: diags
     "id": "battery_brownout",
     "summary": "Battery voltage 0.05V below critical threshold 3.3V at 189.2s (1S)",
     "severity": "critical",
+    "kind": "point",
     "timestamp_us": 189186929,
     "end_timestamp_us": null,
+    "anchor": {
+      "topic": "battery_status",
+      "field": "voltage_v"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "voltage_v",
+          "unit": "volts"
+        },
+        {
+          "name": "critical_threshold_v",
+          "unit": "volts"
+        },
+        {
+          "name": "current_a",
+          "unit": "amps"
+        }
+      ]
+    },
     "evidence": {
       "type": "BatteryBrownout",
       "voltage_v": 0.048304595,
@@ -34,8 +75,29 @@ expression: diags
     "id": "battery_brownout",
     "summary": "Battery voltage 0.05V below critical threshold 3.3V at 219.4s (1S)",
     "severity": "critical",
+    "kind": "point",
     "timestamp_us": 219386927,
     "end_timestamp_us": null,
+    "anchor": {
+      "topic": "battery_status",
+      "field": "voltage_v"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "voltage_v",
+          "unit": "volts"
+        },
+        {
+          "name": "critical_threshold_v",
+          "unit": "volts"
+        },
+        {
+          "name": "current_a",
+          "unit": "amps"
+        }
+      ]
+    },
     "evidence": {
       "type": "BatteryBrownout",
       "voltage_v": 0.05103882,

--- a/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__battery_brownout__tests__snapshot_sample_ulg.snap
+++ b/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__battery_brownout__tests__snapshot_sample_ulg.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/converter/src/diagnostics/battery_brownout.rs
-assertion_line: 270
+source: crates/converter/src/diagnostics/battery_brownout/mod.rs
 expression: diags
 ---
 []

--- a/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__ekf_failure__tests__detects_real_ekf_failure.snap
+++ b/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__ekf_failure__tests__detects_real_ekf_failure.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/converter/src/diagnostics/ekf_failure.rs
-assertion_line: 283
 expression: diags
 ---
 [
@@ -8,8 +7,29 @@ expression: diags
     "id": "ekf_failure",
     "summary": "EKF velocity innovation exceeded threshold for 2.2s starting at 117.3s",
     "severity": "warning",
+    "kind": "region",
     "timestamp_us": 117349822,
     "end_timestamp_us": 119539590,
+    "anchor": {
+      "topic": "estimator_status",
+      "field": "vel_test_ratio"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "innovation",
+          "unit": "label"
+        },
+        {
+          "name": "test_ratio",
+          "unit": "ratio"
+        },
+        {
+          "name": "threshold",
+          "unit": "ratio"
+        }
+      ]
+    },
     "evidence": {
       "type": "EkfFailure",
       "innovation": "velocity",
@@ -21,8 +41,29 @@ expression: diags
     "id": "ekf_failure",
     "summary": "EKF position innovation exceeded threshold for 2.0s starting at 117.9s",
     "severity": "warning",
+    "kind": "region",
     "timestamp_us": 117939397,
     "end_timestamp_us": 119939471,
+    "anchor": {
+      "topic": "estimator_status",
+      "field": "pos_test_ratio"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "innovation",
+          "unit": "label"
+        },
+        {
+          "name": "test_ratio",
+          "unit": "ratio"
+        },
+        {
+          "name": "threshold",
+          "unit": "ratio"
+        }
+      ]
+    },
     "evidence": {
       "type": "EkfFailure",
       "innovation": "position",
@@ -34,8 +75,29 @@ expression: diags
     "id": "ekf_failure",
     "summary": "EKF position innovation exceeded threshold for 5.0s starting at 117.9s",
     "severity": "critical",
+    "kind": "region",
     "timestamp_us": 117939397,
     "end_timestamp_us": 122949150,
+    "anchor": {
+      "topic": "estimator_status",
+      "field": "pos_test_ratio"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "innovation",
+          "unit": "label"
+        },
+        {
+          "name": "test_ratio",
+          "unit": "ratio"
+        },
+        {
+          "name": "threshold",
+          "unit": "ratio"
+        }
+      ]
+    },
     "evidence": {
       "type": "EkfFailure",
       "innovation": "position",

--- a/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__ekf_failure__tests__detects_real_ekf_failure.snap
+++ b/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__ekf_failure__tests__detects_real_ekf_failure.snap
@@ -7,9 +7,12 @@ expression: diags
     "id": "ekf_failure",
     "summary": "EKF velocity innovation exceeded threshold for 2.2s starting at 117.3s",
     "severity": "warning",
-    "kind": "region",
+    "kind": {
+      "region": {
+        "end_timestamp_us": 119539590
+      }
+    },
     "timestamp_us": 117349822,
-    "end_timestamp_us": 119539590,
     "anchor": {
       "topic": "estimator_status",
       "field": "vel_test_ratio"
@@ -41,9 +44,12 @@ expression: diags
     "id": "ekf_failure",
     "summary": "EKF position innovation exceeded threshold for 2.0s starting at 117.9s",
     "severity": "warning",
-    "kind": "region",
+    "kind": {
+      "region": {
+        "end_timestamp_us": 119939471
+      }
+    },
     "timestamp_us": 117939397,
-    "end_timestamp_us": 119939471,
     "anchor": {
       "topic": "estimator_status",
       "field": "pos_test_ratio"
@@ -75,9 +81,12 @@ expression: diags
     "id": "ekf_failure",
     "summary": "EKF position innovation exceeded threshold for 5.0s starting at 117.9s",
     "severity": "critical",
-    "kind": "region",
+    "kind": {
+      "region": {
+        "end_timestamp_us": 122949150
+      }
+    },
     "timestamp_us": 117939397,
-    "end_timestamp_us": 122949150,
     "anchor": {
       "topic": "estimator_status",
       "field": "pos_test_ratio"

--- a/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__ekf_failure__tests__snapshot_sample_ulg.snap
+++ b/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__ekf_failure__tests__snapshot_sample_ulg.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/converter/src/diagnostics/ekf_failure.rs
-assertion_line: 254
+source: crates/converter/src/diagnostics/ekf_failure/mod.rs
 expression: diags
 ---
 []

--- a/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__gps_interference__tests__detects_real_gps_interference.snap
+++ b/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__gps_interference__tests__detects_real_gps_interference.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/converter/src/diagnostics/gps_interference.rs
-assertion_line: 343
 expression: diags
 ---
 [
@@ -8,8 +7,33 @@ expression: diags
     "id": "gps_interference",
     "summary": "GPS quality degraded at 276.6s: EPV 3750004.2m",
     "severity": "critical",
+    "kind": "point",
     "timestamp_us": 276594637,
     "end_timestamp_us": null,
+    "anchor": {
+      "topic": "vehicle_gps_position",
+      "field": "eph"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "eph_m",
+          "unit": "meters"
+        },
+        {
+          "name": "epv_m",
+          "unit": "meters"
+        },
+        {
+          "name": "num_satellites",
+          "unit": "count"
+        },
+        {
+          "name": "noise_level",
+          "unit": "ratio"
+        }
+      ]
+    },
     "evidence": {
       "type": "GpsInterference",
       "eph_m": 4294967.5,
@@ -22,8 +46,33 @@ expression: diags
     "id": "gps_interference",
     "summary": "GPS quality degraded at 281.6s: EPV 3750004.5m",
     "severity": "critical",
+    "kind": "point",
     "timestamp_us": 281595637,
     "end_timestamp_us": null,
+    "anchor": {
+      "topic": "vehicle_gps_position",
+      "field": "eph"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "eph_m",
+          "unit": "meters"
+        },
+        {
+          "name": "epv_m",
+          "unit": "meters"
+        },
+        {
+          "name": "num_satellites",
+          "unit": "count"
+        },
+        {
+          "name": "noise_level",
+          "unit": "ratio"
+        }
+      ]
+    },
     "evidence": {
       "type": "GpsInterference",
       "eph_m": 4294967.5,
@@ -36,8 +85,33 @@ expression: diags
     "id": "gps_interference",
     "summary": "GPS quality degraded at 286.8s: EPV 3750004.5m",
     "severity": "critical",
+    "kind": "point",
     "timestamp_us": 286798899,
     "end_timestamp_us": null,
+    "anchor": {
+      "topic": "vehicle_gps_position",
+      "field": "eph"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "eph_m",
+          "unit": "meters"
+        },
+        {
+          "name": "epv_m",
+          "unit": "meters"
+        },
+        {
+          "name": "num_satellites",
+          "unit": "count"
+        },
+        {
+          "name": "noise_level",
+          "unit": "ratio"
+        }
+      ]
+    },
     "evidence": {
       "type": "GpsInterference",
       "eph_m": 4294967.5,
@@ -50,8 +124,33 @@ expression: diags
     "id": "gps_interference",
     "summary": "GPS quality degraded at 292.0s: EPV 3750004.8m",
     "severity": "critical",
+    "kind": "point",
     "timestamp_us": 291994636,
     "end_timestamp_us": null,
+    "anchor": {
+      "topic": "vehicle_gps_position",
+      "field": "eph"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "eph_m",
+          "unit": "meters"
+        },
+        {
+          "name": "epv_m",
+          "unit": "meters"
+        },
+        {
+          "name": "num_satellites",
+          "unit": "count"
+        },
+        {
+          "name": "noise_level",
+          "unit": "ratio"
+        }
+      ]
+    },
     "evidence": {
       "type": "GpsInterference",
       "eph_m": 4294967.5,
@@ -64,8 +163,33 @@ expression: diags
     "id": "gps_interference",
     "summary": "GPS quality degraded at 297.0s: EPV 3750005.0m",
     "severity": "critical",
+    "kind": "point",
     "timestamp_us": 296994639,
     "end_timestamp_us": null,
+    "anchor": {
+      "topic": "vehicle_gps_position",
+      "field": "eph"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "eph_m",
+          "unit": "meters"
+        },
+        {
+          "name": "epv_m",
+          "unit": "meters"
+        },
+        {
+          "name": "num_satellites",
+          "unit": "count"
+        },
+        {
+          "name": "noise_level",
+          "unit": "ratio"
+        }
+      ]
+    },
     "evidence": {
       "type": "GpsInterference",
       "eph_m": 4294967.5,
@@ -78,8 +202,33 @@ expression: diags
     "id": "gps_interference",
     "summary": "GPS quality degraded at 302.2s: EPV 3750005.2m",
     "severity": "critical",
+    "kind": "point",
     "timestamp_us": 302194643,
     "end_timestamp_us": null,
+    "anchor": {
+      "topic": "vehicle_gps_position",
+      "field": "eph"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "eph_m",
+          "unit": "meters"
+        },
+        {
+          "name": "epv_m",
+          "unit": "meters"
+        },
+        {
+          "name": "num_satellites",
+          "unit": "count"
+        },
+        {
+          "name": "noise_level",
+          "unit": "ratio"
+        }
+      ]
+    },
     "evidence": {
       "type": "GpsInterference",
       "eph_m": 4294967.5,
@@ -92,8 +241,33 @@ expression: diags
     "id": "gps_interference",
     "summary": "GPS quality degraded at 307.2s: EPV 3750005.2m",
     "severity": "critical",
+    "kind": "point",
     "timestamp_us": 307196637,
     "end_timestamp_us": null,
+    "anchor": {
+      "topic": "vehicle_gps_position",
+      "field": "eph"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "eph_m",
+          "unit": "meters"
+        },
+        {
+          "name": "epv_m",
+          "unit": "meters"
+        },
+        {
+          "name": "num_satellites",
+          "unit": "count"
+        },
+        {
+          "name": "noise_level",
+          "unit": "ratio"
+        }
+      ]
+    },
     "evidence": {
       "type": "GpsInterference",
       "eph_m": 4294967.5,
@@ -106,8 +280,33 @@ expression: diags
     "id": "gps_interference",
     "summary": "GPS quality degraded at 312.4s: EPV 3750005.5m",
     "severity": "critical",
+    "kind": "point",
     "timestamp_us": 312394638,
     "end_timestamp_us": null,
+    "anchor": {
+      "topic": "vehicle_gps_position",
+      "field": "eph"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "eph_m",
+          "unit": "meters"
+        },
+        {
+          "name": "epv_m",
+          "unit": "meters"
+        },
+        {
+          "name": "num_satellites",
+          "unit": "count"
+        },
+        {
+          "name": "noise_level",
+          "unit": "ratio"
+        }
+      ]
+    },
     "evidence": {
       "type": "GpsInterference",
       "eph_m": 4294967.5,
@@ -120,8 +319,33 @@ expression: diags
     "id": "gps_interference",
     "summary": "GPS quality degraded at 317.4s: EPV 3750005.8m",
     "severity": "critical",
+    "kind": "point",
     "timestamp_us": 317395912,
     "end_timestamp_us": null,
+    "anchor": {
+      "topic": "vehicle_gps_position",
+      "field": "eph"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "eph_m",
+          "unit": "meters"
+        },
+        {
+          "name": "epv_m",
+          "unit": "meters"
+        },
+        {
+          "name": "num_satellites",
+          "unit": "count"
+        },
+        {
+          "name": "noise_level",
+          "unit": "ratio"
+        }
+      ]
+    },
     "evidence": {
       "type": "GpsInterference",
       "eph_m": 4294967.5,
@@ -134,8 +358,33 @@ expression: diags
     "id": "gps_interference",
     "summary": "GPS quality degraded at 322.4s: EPV 3750005.8m",
     "severity": "critical",
+    "kind": "point",
     "timestamp_us": 322396069,
     "end_timestamp_us": null,
+    "anchor": {
+      "topic": "vehicle_gps_position",
+      "field": "eph"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "eph_m",
+          "unit": "meters"
+        },
+        {
+          "name": "epv_m",
+          "unit": "meters"
+        },
+        {
+          "name": "num_satellites",
+          "unit": "count"
+        },
+        {
+          "name": "noise_level",
+          "unit": "ratio"
+        }
+      ]
+    },
     "evidence": {
       "type": "GpsInterference",
       "eph_m": 4294967.5,
@@ -148,8 +397,33 @@ expression: diags
     "id": "gps_interference",
     "summary": "GPS quality degraded at 327.4s: EPV 3750006.0m",
     "severity": "critical",
+    "kind": "point",
     "timestamp_us": 327397637,
     "end_timestamp_us": null,
+    "anchor": {
+      "topic": "vehicle_gps_position",
+      "field": "eph"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "eph_m",
+          "unit": "meters"
+        },
+        {
+          "name": "epv_m",
+          "unit": "meters"
+        },
+        {
+          "name": "num_satellites",
+          "unit": "count"
+        },
+        {
+          "name": "noise_level",
+          "unit": "ratio"
+        }
+      ]
+    },
     "evidence": {
       "type": "GpsInterference",
       "eph_m": 4294967.5,
@@ -162,8 +436,33 @@ expression: diags
     "id": "gps_interference",
     "summary": "GPS quality degraded at 332.6s: EPV 3750006.0m",
     "severity": "critical",
+    "kind": "point",
     "timestamp_us": 332595636,
     "end_timestamp_us": null,
+    "anchor": {
+      "topic": "vehicle_gps_position",
+      "field": "eph"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "eph_m",
+          "unit": "meters"
+        },
+        {
+          "name": "epv_m",
+          "unit": "meters"
+        },
+        {
+          "name": "num_satellites",
+          "unit": "count"
+        },
+        {
+          "name": "noise_level",
+          "unit": "ratio"
+        }
+      ]
+    },
     "evidence": {
       "type": "GpsInterference",
       "eph_m": 4294967.5,

--- a/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__gps_interference__tests__detects_real_gps_interference.snap
+++ b/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__gps_interference__tests__detects_real_gps_interference.snap
@@ -9,7 +9,6 @@ expression: diags
     "severity": "critical",
     "kind": "point",
     "timestamp_us": 276594637,
-    "end_timestamp_us": null,
     "anchor": {
       "topic": "vehicle_gps_position",
       "field": "eph"
@@ -48,7 +47,6 @@ expression: diags
     "severity": "critical",
     "kind": "point",
     "timestamp_us": 281595637,
-    "end_timestamp_us": null,
     "anchor": {
       "topic": "vehicle_gps_position",
       "field": "eph"
@@ -87,7 +85,6 @@ expression: diags
     "severity": "critical",
     "kind": "point",
     "timestamp_us": 286798899,
-    "end_timestamp_us": null,
     "anchor": {
       "topic": "vehicle_gps_position",
       "field": "eph"
@@ -126,7 +123,6 @@ expression: diags
     "severity": "critical",
     "kind": "point",
     "timestamp_us": 291994636,
-    "end_timestamp_us": null,
     "anchor": {
       "topic": "vehicle_gps_position",
       "field": "eph"
@@ -165,7 +161,6 @@ expression: diags
     "severity": "critical",
     "kind": "point",
     "timestamp_us": 296994639,
-    "end_timestamp_us": null,
     "anchor": {
       "topic": "vehicle_gps_position",
       "field": "eph"
@@ -204,7 +199,6 @@ expression: diags
     "severity": "critical",
     "kind": "point",
     "timestamp_us": 302194643,
-    "end_timestamp_us": null,
     "anchor": {
       "topic": "vehicle_gps_position",
       "field": "eph"
@@ -243,7 +237,6 @@ expression: diags
     "severity": "critical",
     "kind": "point",
     "timestamp_us": 307196637,
-    "end_timestamp_us": null,
     "anchor": {
       "topic": "vehicle_gps_position",
       "field": "eph"
@@ -282,7 +275,6 @@ expression: diags
     "severity": "critical",
     "kind": "point",
     "timestamp_us": 312394638,
-    "end_timestamp_us": null,
     "anchor": {
       "topic": "vehicle_gps_position",
       "field": "eph"
@@ -321,7 +313,6 @@ expression: diags
     "severity": "critical",
     "kind": "point",
     "timestamp_us": 317395912,
-    "end_timestamp_us": null,
     "anchor": {
       "topic": "vehicle_gps_position",
       "field": "eph"
@@ -360,7 +351,6 @@ expression: diags
     "severity": "critical",
     "kind": "point",
     "timestamp_us": 322396069,
-    "end_timestamp_us": null,
     "anchor": {
       "topic": "vehicle_gps_position",
       "field": "eph"
@@ -399,7 +389,6 @@ expression: diags
     "severity": "critical",
     "kind": "point",
     "timestamp_us": 327397637,
-    "end_timestamp_us": null,
     "anchor": {
       "topic": "vehicle_gps_position",
       "field": "eph"
@@ -438,7 +427,6 @@ expression: diags
     "severity": "critical",
     "kind": "point",
     "timestamp_us": 332595636,
-    "end_timestamp_us": null,
     "anchor": {
       "topic": "vehicle_gps_position",
       "field": "eph"

--- a/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__gps_interference__tests__snapshot_sample_ulg.snap
+++ b/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__gps_interference__tests__snapshot_sample_ulg.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/converter/src/diagnostics/gps_interference.rs
-assertion_line: 315
+source: crates/converter/src/diagnostics/gps_interference/mod.rs
 expression: diags
 ---
 []

--- a/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__motor_failure__tests__detects_real_motor_failure.snap
+++ b/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__motor_failure__tests__detects_real_motor_failure.snap
@@ -26,6 +26,10 @@ expression: diags
         {
           "name": "flight_mode",
           "unit": "label"
+        },
+        {
+          "name": "mode",
+          "unit": "label"
         }
       ]
     },
@@ -59,6 +63,10 @@ expression: diags
         },
         {
           "name": "flight_mode",
+          "unit": "label"
+        },
+        {
+          "name": "mode",
           "unit": "label"
         }
       ]
@@ -94,6 +102,10 @@ expression: diags
         {
           "name": "flight_mode",
           "unit": "label"
+        },
+        {
+          "name": "mode",
+          "unit": "label"
         }
       ]
     },
@@ -127,6 +139,10 @@ expression: diags
         },
         {
           "name": "flight_mode",
+          "unit": "label"
+        },
+        {
+          "name": "mode",
           "unit": "label"
         }
       ]
@@ -162,6 +178,10 @@ expression: diags
         {
           "name": "flight_mode",
           "unit": "label"
+        },
+        {
+          "name": "mode",
+          "unit": "label"
         }
       ]
     },
@@ -195,6 +215,10 @@ expression: diags
         },
         {
           "name": "flight_mode",
+          "unit": "label"
+        },
+        {
+          "name": "mode",
           "unit": "label"
         }
       ]

--- a/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__motor_failure__tests__detects_real_motor_failure.snap
+++ b/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__motor_failure__tests__detects_real_motor_failure.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/converter/src/diagnostics/motor_failure.rs
-assertion_line: 391
 expression: diags
 ---
 [
@@ -8,13 +7,34 @@ expression: diags
     "id": "motor_failure",
     "summary": "Motor 0 output dropped to 0 PWM at 5081.8s while armed in Mission mode",
     "severity": "critical",
+    "kind": "point",
     "timestamp_us": 5081817622,
     "end_timestamp_us": null,
+    "anchor": {
+      "topic": "actuator_outputs",
+      "field": "output[0]"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "motor_index",
+          "unit": "count"
+        },
+        {
+          "name": "pwm_value",
+          "unit": "pwm"
+        },
+        {
+          "name": "flight_mode",
+          "unit": "label"
+        }
+      ]
+    },
     "evidence": {
       "type": "MotorFailure",
       "motor_index": 0,
       "pwm_value": 0.0,
-      "failure_mode": "drop_to_zero",
+      "mode": "drop_to_zero",
       "flight_mode": "Mission"
     }
   },
@@ -22,13 +42,34 @@ expression: diags
     "id": "motor_failure",
     "summary": "Motor 1 output dropped to 0 PWM at 5081.8s while armed in Mission mode",
     "severity": "critical",
+    "kind": "point",
     "timestamp_us": 5081817622,
     "end_timestamp_us": null,
+    "anchor": {
+      "topic": "actuator_outputs",
+      "field": "output[1]"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "motor_index",
+          "unit": "count"
+        },
+        {
+          "name": "pwm_value",
+          "unit": "pwm"
+        },
+        {
+          "name": "flight_mode",
+          "unit": "label"
+        }
+      ]
+    },
     "evidence": {
       "type": "MotorFailure",
       "motor_index": 1,
       "pwm_value": 0.0,
-      "failure_mode": "drop_to_zero",
+      "mode": "drop_to_zero",
       "flight_mode": "Mission"
     }
   },
@@ -36,13 +77,34 @@ expression: diags
     "id": "motor_failure",
     "summary": "Motor 2 output dropped to 0 PWM at 5081.8s while armed in Mission mode",
     "severity": "critical",
+    "kind": "point",
     "timestamp_us": 5081817622,
     "end_timestamp_us": null,
+    "anchor": {
+      "topic": "actuator_outputs",
+      "field": "output[2]"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "motor_index",
+          "unit": "count"
+        },
+        {
+          "name": "pwm_value",
+          "unit": "pwm"
+        },
+        {
+          "name": "flight_mode",
+          "unit": "label"
+        }
+      ]
+    },
     "evidence": {
       "type": "MotorFailure",
       "motor_index": 2,
       "pwm_value": 0.0,
-      "failure_mode": "drop_to_zero",
+      "mode": "drop_to_zero",
       "flight_mode": "Mission"
     }
   },
@@ -50,13 +112,34 @@ expression: diags
     "id": "motor_failure",
     "summary": "Motor 3 output dropped to 0 PWM at 5081.8s while armed in Mission mode",
     "severity": "critical",
+    "kind": "point",
     "timestamp_us": 5081817622,
     "end_timestamp_us": null,
+    "anchor": {
+      "topic": "actuator_outputs",
+      "field": "output[3]"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "motor_index",
+          "unit": "count"
+        },
+        {
+          "name": "pwm_value",
+          "unit": "pwm"
+        },
+        {
+          "name": "flight_mode",
+          "unit": "label"
+        }
+      ]
+    },
     "evidence": {
       "type": "MotorFailure",
       "motor_index": 3,
       "pwm_value": 0.0,
-      "failure_mode": "drop_to_zero",
+      "mode": "drop_to_zero",
       "flight_mode": "Mission"
     }
   },
@@ -64,13 +147,34 @@ expression: diags
     "id": "motor_failure",
     "summary": "Motor 4 output dropped to 0 PWM at 5081.8s while armed in Mission mode",
     "severity": "critical",
+    "kind": "point",
     "timestamp_us": 5081817622,
     "end_timestamp_us": null,
+    "anchor": {
+      "topic": "actuator_outputs",
+      "field": "output[4]"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "motor_index",
+          "unit": "count"
+        },
+        {
+          "name": "pwm_value",
+          "unit": "pwm"
+        },
+        {
+          "name": "flight_mode",
+          "unit": "label"
+        }
+      ]
+    },
     "evidence": {
       "type": "MotorFailure",
       "motor_index": 4,
       "pwm_value": 0.0,
-      "failure_mode": "drop_to_zero",
+      "mode": "drop_to_zero",
       "flight_mode": "Mission"
     }
   },
@@ -78,13 +182,34 @@ expression: diags
     "id": "motor_failure",
     "summary": "Motor 5 output dropped to 0 PWM at 5081.8s while armed in Mission mode",
     "severity": "critical",
+    "kind": "point",
     "timestamp_us": 5081817622,
     "end_timestamp_us": null,
+    "anchor": {
+      "topic": "actuator_outputs",
+      "field": "output[5]"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "motor_index",
+          "unit": "count"
+        },
+        {
+          "name": "pwm_value",
+          "unit": "pwm"
+        },
+        {
+          "name": "flight_mode",
+          "unit": "label"
+        }
+      ]
+    },
     "evidence": {
       "type": "MotorFailure",
       "motor_index": 5,
       "pwm_value": 0.0,
-      "failure_mode": "drop_to_zero",
+      "mode": "drop_to_zero",
       "flight_mode": "Mission"
     }
   }

--- a/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__motor_failure__tests__detects_real_motor_failure.snap
+++ b/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__motor_failure__tests__detects_real_motor_failure.snap
@@ -9,7 +9,6 @@ expression: diags
     "severity": "critical",
     "kind": "point",
     "timestamp_us": 5081817622,
-    "end_timestamp_us": null,
     "anchor": {
       "topic": "actuator_outputs",
       "field": "output[0]"
@@ -44,7 +43,6 @@ expression: diags
     "severity": "critical",
     "kind": "point",
     "timestamp_us": 5081817622,
-    "end_timestamp_us": null,
     "anchor": {
       "topic": "actuator_outputs",
       "field": "output[1]"
@@ -79,7 +77,6 @@ expression: diags
     "severity": "critical",
     "kind": "point",
     "timestamp_us": 5081817622,
-    "end_timestamp_us": null,
     "anchor": {
       "topic": "actuator_outputs",
       "field": "output[2]"
@@ -114,7 +111,6 @@ expression: diags
     "severity": "critical",
     "kind": "point",
     "timestamp_us": 5081817622,
-    "end_timestamp_us": null,
     "anchor": {
       "topic": "actuator_outputs",
       "field": "output[3]"
@@ -149,7 +145,6 @@ expression: diags
     "severity": "critical",
     "kind": "point",
     "timestamp_us": 5081817622,
-    "end_timestamp_us": null,
     "anchor": {
       "topic": "actuator_outputs",
       "field": "output[4]"
@@ -184,7 +179,6 @@ expression: diags
     "severity": "critical",
     "kind": "point",
     "timestamp_us": 5081817622,
-    "end_timestamp_us": null,
     "anchor": {
       "topic": "actuator_outputs",
       "field": "output[5]"

--- a/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__motor_failure__tests__snapshot_sample_ulg.snap
+++ b/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__motor_failure__tests__snapshot_sample_ulg.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/converter/src/diagnostics/motor_failure.rs
-assertion_line: 298
+source: crates/converter/src/diagnostics/motor_failure/mod.rs
 expression: diags
 ---
 []

--- a/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__rc_loss__tests__snapshot_sample_ulg.snap
+++ b/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__rc_loss__tests__snapshot_sample_ulg.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/converter/src/diagnostics/rc_loss.rs
-assertion_line: 303
+source: crates/converter/src/diagnostics/rc_loss/mod.rs
 expression: diags
 ---
 []

--- a/crates/converter/src/diagnostics/testing.rs
+++ b/crates/converter/src/diagnostics/testing.rs
@@ -231,3 +231,86 @@ pub fn assert_no_false_positives(fixture: &str, diagnostic_id: &str) {
         diags
     );
 }
+
+/// Assert descriptor field names == evidence JSON keys (minus "type" tag)
+/// for every analyzer with a `{id}.ulg` fixture.
+#[test]
+fn descriptor_fields_match_evidence_keys() {
+    use std::collections::BTreeSet;
+
+    let analyzers = super::create_analyzers();
+    let mut tested = Vec::new();
+    let mut skipped = Vec::new();
+
+    for analyzer in analyzers {
+        let id = analyzer.id().to_string();
+        let descriptor = analyzer.output_descriptor();
+
+        // Discover fixture by convention
+        let fixture_name = format!("{}.ulg", id);
+        let fixture_file = fixture_path(&fixture_name);
+        if !std::path::Path::new(&fixture_file).exists() {
+            skipped.push(id);
+            continue;
+        }
+
+        let diags = analyze_fixture_for(&fixture_name, &id);
+        assert!(
+            !diags.is_empty(),
+            "analyzer '{}' produced no diagnostics from fixture '{}' — \
+             can't verify descriptor parity",
+            id, fixture_name,
+        );
+
+        let descriptor_names: BTreeSet<String> = descriptor
+            .fields
+            .iter()
+            .map(|f| f.name.clone())
+            .collect();
+
+        for diag in &diags {
+            let evidence_json = serde_json::to_value(&diag.evidence)
+                .expect("Evidence must serialize");
+            let evidence_obj = evidence_json
+                .as_object()
+                .expect("Evidence must serialize to JSON object");
+
+            let evidence_names: BTreeSet<String> = evidence_obj
+                .keys()
+                .filter(|k| *k != "type")
+                .cloned()
+                .collect();
+
+            assert_eq!(
+                descriptor_names, evidence_names,
+                "descriptor/evidence field mismatch for '{}'\n\
+                 descriptor declares: {:?}\n\
+                 evidence contains:   {:?}\n\
+                 missing from descriptor: {:?}\n\
+                 extra in descriptor:     {:?}",
+                id,
+                descriptor_names,
+                evidence_names,
+                evidence_names.difference(&descriptor_names).collect::<Vec<_>>(),
+                descriptor_names.difference(&evidence_names).collect::<Vec<_>>(),
+            );
+        }
+
+        tested.push(id);
+    }
+
+    // Ensure we actually tested something — if all analyzers are skipped,
+    // this test is vacuous and should fail loudly.
+    assert!(
+        !tested.is_empty(),
+        "no analyzers were tested — all skipped: {:?}",
+        skipped,
+    );
+
+    if !skipped.is_empty() {
+        eprintln!(
+            "NOTE: skipped descriptor parity check for analyzers without fixtures: {:?}",
+            skipped,
+        );
+    }
+}

--- a/crates/server/src/api/upload.rs
+++ b/crates/server/src/api/upload.rs
@@ -215,7 +215,10 @@ pub async fn upload(
                     severity: format!("{:?}", d.severity).to_lowercase(),
                     summary: d.summary.clone(),
                     timestamp_us: Some(d.timestamp_us as i64),
-                    end_timestamp_us: d.end_timestamp_us.map(|t| t as i64),
+                    end_timestamp_us: match &d.kind {
+                        flight_review::diagnostics::AnomalyKind::Region { end_timestamp_us } => Some(*end_timestamp_us as i64),
+                        flight_review::diagnostics::AnomalyKind::Point => None,
+                    },
                     evidence: serde_json::to_string(&d.evidence).ok(),
                 })
                 .collect();

--- a/scripts/ci/check-analyzer.sh
+++ b/scripts/ci/check-analyzer.sh
@@ -13,6 +13,7 @@
 #      - snapshot test
 #   4. Is registered in create_analyzers() factory
 #   5. Has an Evidence enum variant
+#   6. Implements output_descriptor()
 #
 # Usage: scripts/ci/check-analyzer.sh [--changed-only]
 #   --changed-only: only check analyzers modified in the current PR
@@ -36,23 +37,25 @@ if [[ "${1:-}" == "--changed-only" ]]; then
     # Get files changed in this PR vs main
     changed_files=$(git diff --name-only origin/main...HEAD -- "$DIAG_DIR/" 2>/dev/null || \
                     git diff --name-only HEAD~1 -- "$DIAG_DIR/" 2>/dev/null || echo "")
+
+    # Extract unique analyzer names from changed paths
+    analyzer_names=$(echo "$changed_files" \
+        | sed -n 's|^crates/converter/src/diagnostics/\([^/.]*\)\.rs$|\1|p' \
+        | grep -v -E '^(mod|testing)$' \
+        | sort -u)
+
     analyzer_files=""
-    for f in $changed_files; do
-        base=$(basename "$f")
-        # Skip mod.rs, testing.rs, snapshots
-        if [[ "$base" != "mod.rs" && "$base" != "testing.rs" && "$base" == *.rs ]]; then
-            full="$REPO_ROOT/$f"
-            if [[ -f "$full" ]]; then
-                analyzer_files="$analyzer_files $full"
-            fi
-        fi
+    for name in $analyzer_names; do
+        [[ -f "$DIAG_DIR/${name}.rs" ]] && analyzer_files="$analyzer_files $DIAG_DIR/${name}.rs"
     done
+
     if [[ -z "$analyzer_files" ]]; then
         echo "No analyzer files changed. Skipping checks."
         exit 0
     fi
 else
-    analyzer_files=$(find "$DIAG_DIR" -name "*.rs" \
+    # Find all analyzer .rs files (excluding mod.rs, testing.rs)
+    analyzer_files=$(find "$DIAG_DIR" -maxdepth 1 -name "*.rs" \
         ! -name "mod.rs" \
         ! -name "testing.rs" \
         | sort)
@@ -119,7 +122,6 @@ for analyzer_file in $analyzer_files; do
     fi
 
     # 4. Check registered in create_analyzers()
-    # Look for the struct name in the factory function
     struct_name=$(grep -o 'pub struct [A-Za-z]*' "$analyzer_file" | head -1 | awk '{print $3}')
     if [[ -n "$struct_name" ]] && grep -q "$struct_name" "$MOD_FILE"; then
         ok "registered in create_analyzers()"
@@ -128,22 +130,23 @@ for analyzer_file in $analyzer_files; do
     fi
 
     # 5. Check Evidence enum variant exists
-    # Extract the id string from the analyzer
-    analyzer_id=$(grep -A1 'fn id' "$analyzer_file" | grep '"' | tr -d ' "' || true)
-    if [[ -n "$analyzer_id" ]]; then
-        # Check Evidence enum has a variant (heuristic: CamelCase of the id)
-        if grep -q "^    [A-Z].*{" "$MOD_FILE" | head -20 && \
-           grep -q "evidence: Evidence::" "$analyzer_file"; then
-            ok "uses Evidence enum variant"
-        else
-            warn "$name: could not verify Evidence variant"
-        fi
+    if grep -q "evidence: Evidence::" "$analyzer_file"; then
+        ok "uses Evidence enum variant"
+    else
+        err "$name: missing Evidence enum variant usage"
+    fi
+
+    # 6. Check output_descriptor() is implemented
+    if grep -q 'fn output_descriptor' "$analyzer_file"; then
+        ok "implements output_descriptor()"
+    else
+        err "$name: missing fn output_descriptor() implementation"
     fi
 
     echo
 done
 
-# 6. Check that all analyzer modules are declared in mod.rs
+# 7. Check that all analyzer modules are declared in mod.rs
 echo "--- mod.rs declarations ---"
 for analyzer_file in $analyzer_files; do
     name=$(basename "$analyzer_file" .rs)


### PR DESCRIPTION
# Typed output descriptors for diagnostic analyzers

Each analyzer now describes its output via `output_descriptor()` on the `Analyzer` trait. The descriptor is embedded on every `Diagnostic` and baked into `metadata.json` at ingest for immutability guarantees.

## What changed

**New types** (`mod.rs`):
- `AnomalyKind` — `Point` or `Region { end_timestamp_us }` (invalid states unrepresentable)
- `PlotAnchor` — per-instance `(topic, field)` for plot anchoring
- `OutputDescriptor` / `FieldDescriptor` / `FieldUnit` — typed field semantics
- `MotorFailureMode` — replaces `failure_mode: String`

**`Diagnostic` struct** gains `kind`, `anchor`, `descriptor`; `end_timestamp_us` moves into `AnomalyKind::Region`.

**`Analyzer` trait** adds required `fn output_descriptor() -> OutputDescriptor`.

**All 6 analyzers** updated: `battery_brownout`, `ekf_failure`, `ekf_selector_whipsaw`, `gps_interference`, `motor_failure`, `rc_loss`.

**Server** (`upload.rs`): extracts `end_timestamp_us` via pattern match on `AnomalyKind::Region`.

## Enforcement

`descriptor_fields_match_evidence_keys` test in `testing.rs` walks `create_analyzers()`, runs each against its `{id}.ulg` fixture, and asserts `descriptor.fields[].name == evidence JSON keys - "type"`. Auto-discovers fixtures by convention — new analyzers are covered without updating the test.

## Other changes

- `check-analyzer.sh` updated with an `output_descriptor()` check
- CONTRIBUTING.md: trait method docs, diagnostic field docs, output descriptor guide
- README.md: new "Output Descriptors" section
- All snapshots updated

## metadata.json examples

* battery brownout - [metadata.json](https://github.com/user-attachments/files/29151263/metadata.json)
* ekf failure - [metadata.json](https://github.com/user-attachments/files/29151289/metadata.json)
* motor failure - [metadata.json](https://github.com/user-attachments/files/29151298/metadata.json)
* gps interference - [metadata.json](https://github.com/user-attachments/files/29151305/metadata.json)

```json
{
  "id": "battery_brownout",
  "summary": "Battery voltage 0.06V below critical threshold 3.3V at 159.0s (1S)",
  "severity": "critical",
  "kind": "point",
  "timestamp_us": 158986930,
  "anchor": { "topic": "battery_status", "field": "voltage_v" },
  "descriptor": {
    "fields": [
      { "name": "voltage_v", "unit": "volts" },
      { "name": "critical_threshold_v", "unit": "volts" },
      { "name": "current_a", "unit": "amps" }
    ]
  },
  "evidence": {
    "type": "BatteryBrownout",
    "voltage_v": 0.058,
    "critical_threshold_v": 3.3,
    "current_a": 0.097
  }
}
```

```json
{
  "id": "ekf_failure",
  "summary": "EKF velocity innovation exceeded threshold for 2.2s starting at 117.3s",
  "severity": "warning",
  "kind": { "region": { "end_timestamp_us": 119539590 } },
  "timestamp_us": 117349822,
  "anchor": { "topic": "estimator_status", "field": "vel_test_ratio" },
  "descriptor": {
    "fields": [
      { "name": "innovation", "unit": "label" },
      { "name": "test_ratio", "unit": "ratio" },
      { "name": "threshold", "unit": "ratio" }
    ]
  },
  "evidence": {
    "type": "EkfFailure",
    "innovation": "velocity",
    "test_ratio": 1.137,
    "threshold": 1.0
  }
}
```