### PR TITLE
fix(frontend): serve DuckDB-WASM bundles same-origin to fix Safari

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -3,3 +3,4 @@ build
 .svelte-kit
 .env
 .env.*
+static/duckdb

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "vite dev",
+    "prebuild": "node scripts/sync-duckdb-assets.mjs",
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/frontend/scripts/sync-duckdb-assets.mjs
+++ b/frontend/scripts/sync-duckdb-assets.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// Copy DuckDB-WASM bundle files from node_modules into static/duckdb/.
+// Loading them from the jsDelivr CDN breaks Safari (blob-worker origin issues),
+// so we serve them same-origin from the SvelteKit static directory.
+
+import { mkdirSync, copyFileSync, existsSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+const src = join(root, 'node_modules', '@duckdb', 'duckdb-wasm', 'dist');
+const dest = join(root, 'static', 'duckdb');
+
+const files = [
+  'duckdb-mvp.wasm',
+  'duckdb-eh.wasm',
+  'duckdb-coi.wasm',
+  'duckdb-browser-mvp.worker.js',
+  'duckdb-browser-eh.worker.js',
+  'duckdb-browser-coi.worker.js',
+  'duckdb-browser-coi.pthread.worker.js',
+];
+
+mkdirSync(dest, { recursive: true });
+
+let copied = 0;
+let skipped = 0;
+for (const f of files) {
+  const s = join(src, f);
+  const d = join(dest, f);
+  if (!existsSync(s)) {
+    console.error(`missing source: ${s}`);
+    process.exit(1);
+  }
+  if (existsSync(d) && statSync(d).mtimeMs >= statSync(s).mtimeMs) {
+    skipped++;
+    continue;
+  }
+  copyFileSync(s, d);
+  copied++;
+}
+console.log(`duckdb assets: ${copied} copied, ${skipped} up-to-date`);

--- a/frontend/src/lib/utils/duckdb.ts
+++ b/frontend/src/lib/utils/duckdb.ts
@@ -1,19 +1,35 @@
-import type { AsyncDuckDB, AsyncDuckDBConnection } from '@duckdb/duckdb-wasm';
+import type { AsyncDuckDB, AsyncDuckDBConnection, DuckDBBundles } from '@duckdb/duckdb-wasm';
 
 let dbInstance: AsyncDuckDB | null = null;
+
+// Same-origin bundle map. Files are served from /duckdb/* — by the Vite dev
+// plugin in dev, and from static/duckdb/ in prod (synced at build time).
+// Loading from a CDN breaks Safari because the worker ends up with an opaque
+// origin and can't fetch the .wasm module.
+function getBundles(): DuckDBBundles {
+  return {
+    mvp: {
+      mainModule: '/duckdb/duckdb-mvp.wasm',
+      mainWorker: '/duckdb/duckdb-browser-mvp.worker.js',
+    },
+    eh: {
+      mainModule: '/duckdb/duckdb-eh.wasm',
+      mainWorker: '/duckdb/duckdb-browser-eh.worker.js',
+    },
+    coi: {
+      mainModule: '/duckdb/duckdb-coi.wasm',
+      mainWorker: '/duckdb/duckdb-browser-coi.worker.js',
+      pthreadWorker: '/duckdb/duckdb-browser-coi.pthread.worker.js',
+    },
+  };
+}
 
 export async function initDuckDB(): Promise<AsyncDuckDB> {
   if (dbInstance) return dbInstance;
   const duckdb = await import('@duckdb/duckdb-wasm');
-  const BUNDLES = duckdb.getJsDelivrBundles();
-  const bundle = await duckdb.selectBundle(BUNDLES);
+  const bundle = await duckdb.selectBundle(getBundles());
 
-  // Fetch the worker script as a blob to avoid cross-origin Worker restrictions.
-  // Creating a Worker directly from a CDN URL fails when the page is on a different origin.
-  const workerScript = await fetch(bundle.mainWorker!).then((r) => r.blob());
-  const workerUrl = URL.createObjectURL(workerScript);
-  const worker = new Worker(workerUrl);
-
+  const worker = new Worker(bundle.mainWorker!);
   const logger = new duckdb.ConsoleLogger();
   const db = new duckdb.AsyncDuckDB(logger, worker);
   await db.instantiate(bundle.mainModule, bundle.pthreadWorker);

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,16 +6,15 @@ import { join } from 'node:path';
 import type { Plugin } from 'vite';
 
 /**
- * Serve DuckDB worker source-map files from node_modules during dev.
+ * Serve DuckDB-WASM bundle files (workers, wasm, source maps) from node_modules
+ * under /duckdb/* during dev.
  *
- * The DuckDB WASM worker is loaded via a blob URL (fetched from a CDN).
- * The worker script contains a `//# sourceMappingURL=<file>.map` comment,
- * which the browser resolves relative to the page origin, hitting the Vite
- * dev server and producing a 404. This plugin intercepts those requests and
- * serves the corresponding .map file from the installed package.
+ * Loading workers/wasm from the jsDelivr CDN breaks in Safari: the worker is
+ * created from a blob URL with an opaque origin, and subsequent fetches for
+ * the .wasm module are blocked. Serving everything same-origin avoids this.
  */
-function duckdbWorkerSourcemaps(): Plugin {
-  const DUCKDB_MAP_RE = /^\/(duckdb-browser-.+\.worker\.js\.map)$/;
+function duckdbAssets(): Plugin {
+  const DUCKDB_RE = /^\/duckdb\/(duckdb-[A-Za-z0-9._-]+)$/;
   const distDir = join(
     __dirname,
     'node_modules',
@@ -24,16 +23,24 @@ function duckdbWorkerSourcemaps(): Plugin {
     'dist',
   );
 
+  const contentType = (file: string): string => {
+    if (file.endsWith('.wasm')) return 'application/wasm';
+    if (file.endsWith('.js')) return 'application/javascript';
+    if (file.endsWith('.map')) return 'application/json';
+    return 'application/octet-stream';
+  };
+
   return {
-    name: 'duckdb-worker-sourcemaps',
+    name: 'duckdb-assets',
     apply: 'serve', // dev only
     configureServer(server) {
       server.middlewares.use((req, res, next) => {
-        const match = req.url && DUCKDB_MAP_RE.exec(req.url);
+        const match = req.url && DUCKDB_RE.exec(req.url.split('?')[0]);
         if (!match) return next();
         try {
           const content = readFileSync(join(distDir, match[1]));
-          res.setHeader('Content-Type', 'application/json');
+          res.setHeader('Content-Type', contentType(match[1]));
+          res.setHeader('Cache-Control', 'no-cache');
           res.end(content);
         } catch {
           next();
@@ -44,7 +51,7 @@ function duckdbWorkerSourcemaps(): Plugin {
 }
 
 export default defineConfig({
-  plugins: [duckdbWorkerSourcemaps(), tailwindcss(), sveltekit()],
+  plugins: [duckdbAssets(), tailwindcss(), sveltekit()],
   server: {
     proxy: {
       '/api': {


### PR DESCRIPTION
DuckDB-WASM is currently loaded from the jsDelivr CDN, which breaks in Safari. The worker is created from a blob URL with an opaque origin, and the workers subsequent fetch for the `.wasm` module is then blocked, so the database never initializes.

This serves the bundles same-origin instead. In dev, the existing Vite plugin is generalized from serving only worker source maps to serving the full bundle (workers, wasm, maps) under `/duckdb/*` from `node_modules`, with correct content types. In prod, a `prebuild` script syncs the bundle files into `static/duckdb/` so they ship same-origin with the app. `duckdb.ts` switches from `getJsDelivrBundles()` to an explicit same-origin bundle map and drops the blob-fetch workaround.

Pulled out of #16, which had this riding along with an unrelated analyzer change.