### PR TITLE
fix: recover truncated ULog logs instead of producing no output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2313,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "px4-ulog"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fef6eb88b448990245f7ad0bf05f5289f8745ad3b727be5e0aac25ba6f7b557"
+checksum = "d31986c7f5754792e62c15b93cc5e9c5affdd867a33cb868b84e7dea0d8e70e5"
 dependencies = [
  "byteorder",
 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,9 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
 
-# Build release binary with PostgreSQL support
-RUN cargo build --release -p flight-review-server --features postgres \
+# Build release binary with PostgreSQL support by default
+ARG SERVER_FEATURES=postgres
+RUN cargo build --release -p flight-review-server --features "$SERVER_FEATURES" \
     && cargo build --release -p flight-review --bin ulog-convert
 
 # Runtime image — minimal, no Rust toolchain

--- a/crates/converter/Cargo.toml
+++ b/crates/converter/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["px4", "ulog", "parquet", "flight-review", "drone"]
 categories = ["science", "command-line-utilities", "parser-implementations"]
 
 [dependencies]
-px4-ulog = "0.5.0"
+px4-ulog = "0.6.1"
 arrow = "54"
 parquet = { version = "54", features = ["arrow"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/converter/src/converter.rs
+++ b/crates/converter/src/converter.rs
@@ -103,7 +103,8 @@ impl Manifest {
 pub fn convert_ulog(input_path: &str, output_dir: &Path) -> Result<ConvertResult, ConvertError> {
     std::fs::create_dir_all(output_dir).map_err(ConvertError::Parse)?;
 
-    // Parse the ULog file
+    // Parse the ULog file. A truncated or malformed tail no longer fails the
+    // whole parse — read_file returns the valid prefix plus how it ended.
     let parsed = px4_ulog::full_parser::read_file(input_path)?;
 
     // Extract metadata via the streaming parser
@@ -112,6 +113,10 @@ pub fn convert_ulog(input_path: &str, output_dir: &Path) -> Result<ConvertResult
     // Run flight analysis (second streaming pass)
     let analysis = crate::analysis::analyze(input_path, &metadata)?;
     metadata.analysis = Some(analysis);
+
+    // Record how the log ended (complete / truncated / malformed). The full parse
+    // above is authoritative; the streaming passes also recover their prefixes.
+    metadata.completeness = parsed.completeness.clone().into();
 
     // Convert each topic to a Parquet file
     let mut parquet_files = Vec::new();

--- a/crates/converter/src/metadata.rs
+++ b/crates/converter/src/metadata.rs
@@ -60,6 +60,36 @@ pub struct ChangedParam {
     pub in_flight: bool,
 }
 
+/// How the ULog data section ended. Mirrors `px4_ulog::full_parser::Completeness`
+/// (which isn't `Serialize`) so the outcome can be baked into `metadata.json`.
+/// PX4 logs are routinely cut off in the field (power loss, SD card pulled while
+/// armed, firmware crash mid-write); a truncated tail still leaves a usable flight,
+/// so we record the state rather than discarding the log.
+///
+/// Serializes as `"complete"`, `"truncated"`, or `{ "malformed_record": "..." }`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Completeness {
+    /// The data section ended on a clean record boundary. Nothing was lost.
+    #[default]
+    Complete,
+    /// The file ended partway through a record (classic power-loss / yanked-SD cut).
+    Truncated,
+    /// A complete-looking record failed to parse (corruption, schema mismatch).
+    MalformedRecord(String),
+}
+
+impl From<px4_ulog::full_parser::Completeness> for Completeness {
+    fn from(c: px4_ulog::full_parser::Completeness) -> Self {
+        use px4_ulog::full_parser::Completeness as P;
+        match c {
+            P::Complete => Completeness::Complete,
+            P::Truncated => Completeness::Truncated,
+            P::MalformedRecord(s) => Completeness::MalformedRecord(s),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct FlightMetadata {
     /// System name (e.g., "PX4")
@@ -127,6 +157,9 @@ pub struct FlightMetadata {
     pub gps_first_fix: Option<GpsPosition>,
     /// Flight analysis data (computed from a second streaming pass)
     pub analysis: Option<crate::analysis::FlightAnalysis>,
+    /// How the log's data section ended. `Truncated` / `MalformedRecord` mean the
+    /// file was cut off or corrupt and the data above is the recovered valid prefix.
+    pub completeness: Completeness,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/scripts/ci/check-analyzer.sh
+++ b/scripts/ci/check-analyzer.sh
@@ -38,10 +38,14 @@ if [[ "${1:-}" == "--changed-only" ]]; then
     changed_files=$(git diff --name-only origin/main...HEAD -- "$DIAG_DIR/" 2>/dev/null || \
                     git diff --name-only HEAD~1 -- "$DIAG_DIR/" 2>/dev/null || echo "")
 
-    # Extract unique analyzer names from changed paths
+    # Extract unique analyzer names from changed paths.
+    # `grep -v` exits 1 when nothing matches (e.g. only a snapshot or fixture
+    # changed, so sed produced no analyzer names); under `set -e` + `pipefail`
+    # that would abort the whole script before the "nothing changed" check
+    # below. `|| true` keeps an empty result from failing the pipeline.
     analyzer_names=$(echo "$changed_files" \
         | sed -n 's|^crates/converter/src/diagnostics/\([^/.]*\)\.rs$|\1|p' \
-        | grep -v -E '^(mod|testing)$' \
+        | { grep -v -E '^(mod|testing)$' || true; } \
         | sort -u)
 
     analyzer_files=""


### PR DESCRIPTION
A truncated or corrupt ULog tail made `convert_ulog` abort the entire conversion and write nothing — no metadata, no Parquet, no diagnostics — even when almost the whole flight had parsed cleanly. PX4 logs are routinely cut off in the field (power loss, SD card pulled while armed, firmware crash mid-write), and both v1 Flight Review and `pyulog` still surface the partial flight. Batch-scanning the 1000-log v1.17.0 corpus, 11 files failed this way and produced zero output each.

`px4-ulog` 0.6.1 now recovers the valid prefix from a truncated or malformed log instead of erroring (both `read_file` and the streaming callback path). This bumps to it and threads the parse outcome through: a new `Completeness` field on `FlightMetadata` records `complete` / `truncated` / `malformed_record` in `metadata.json`. The enum is a local mirror because the parser's `Completeness` isn't `Serialize` yet (PX4/px4-ulog-rs#9 tracks deriving it upstream, after which this mirror can go away). The streaming metadata and analysis passes simply stop erroring on a recoverable tail.

Verified end to end on the corpus: the ERROR count went from 11 to 0, every previously-failing file now converts its recovered prefix (one went from zero output to 77 topics / 131 Parquet files), and clean logs report `completeness: complete`. `cargo build --workspace` is green and the 73 converter tests pass. No frontend changes here — a "partial log" badge in the viewer is a separate follow-up.

Closes #24
