### PR TITLE
fix: regenerate stale whipsaw snapshot and fix analyzer-check CI abort

### DIFF
--- a/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__ekf_selector_whipsaw__tests__detects_real_ekf_selector_whipsaw.snap
+++ b/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__ekf_selector_whipsaw__tests__detects_real_ekf_selector_whipsaw.snap
@@ -7,8 +7,40 @@ expression: diags
     "id": "ekf_selector_whipsaw",
     "summary": "EKF2 estimator switching rapidly: 3 instance switches in 3.2s, switched to a degraded instance (combined_test_ratio >= 1.0)",
     "severity": "critical",
+    "kind": {
+      "region": {
+        "end_timestamp_us": 216888428
+      }
+    },
     "timestamp_us": 213733233,
-    "end_timestamp_us": 216888428,
+    "anchor": {
+      "topic": "estimator_selector_status",
+      "field": "instance_changed_count"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "switch_count",
+          "unit": "count"
+        },
+        {
+          "name": "window_duration_ms",
+          "unit": "milliseconds"
+        },
+        {
+          "name": "avg_switch_interval_ms",
+          "unit": "milliseconds"
+        },
+        {
+          "name": "switched_to_degraded",
+          "unit": "label"
+        },
+        {
+          "name": "primary_instance_test_ratio",
+          "unit": "ratio"
+        }
+      ]
+    },
     "evidence": {
       "type": "EkfSelectorWhipsaw",
       "switch_count": 3,
@@ -22,8 +54,40 @@ expression: diags
     "id": "ekf_selector_whipsaw",
     "summary": "EKF2 estimator switching rapidly: 3 instance switches in 4.6s, switched to a degraded instance (combined_test_ratio >= 1.0)",
     "severity": "critical",
+    "kind": {
+      "region": {
+        "end_timestamp_us": 276313140
+      }
+    },
     "timestamp_us": 271708159,
-    "end_timestamp_us": 276313140,
+    "anchor": {
+      "topic": "estimator_selector_status",
+      "field": "instance_changed_count"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "switch_count",
+          "unit": "count"
+        },
+        {
+          "name": "window_duration_ms",
+          "unit": "milliseconds"
+        },
+        {
+          "name": "avg_switch_interval_ms",
+          "unit": "milliseconds"
+        },
+        {
+          "name": "switched_to_degraded",
+          "unit": "label"
+        },
+        {
+          "name": "primary_instance_test_ratio",
+          "unit": "ratio"
+        }
+      ]
+    },
     "evidence": {
       "type": "EkfSelectorWhipsaw",
       "switch_count": 3,

--- a/scripts/ci/check-analyzer.sh
+++ b/scripts/ci/check-analyzer.sh
@@ -38,10 +38,14 @@ if [[ "${1:-}" == "--changed-only" ]]; then
     changed_files=$(git diff --name-only origin/main...HEAD -- "$DIAG_DIR/" 2>/dev/null || \
                     git diff --name-only HEAD~1 -- "$DIAG_DIR/" 2>/dev/null || echo "")
 
-    # Extract unique analyzer names from changed paths
+    # Extract unique analyzer names from changed paths.
+    # `grep -v` exits 1 when nothing matches (e.g. only a snapshot or fixture
+    # changed, so sed produced no analyzer names); under `set -e` + `pipefail`
+    # that would abort the whole script before the "nothing changed" check
+    # below. `|| true` keeps an empty result from failing the pipeline.
     analyzer_names=$(echo "$changed_files" \
         | sed -n 's|^crates/converter/src/diagnostics/\([^/.]*\)\.rs$|\1|p' \
-        | grep -v -E '^(mod|testing)$' \
+        | { grep -v -E '^(mod|testing)$' || true; } \
         | sort -u)
 
     analyzer_files=""


### PR DESCRIPTION
Two related diagnostics-CI fixes that together unblock `main`.

First, the `ekf_selector_whipsaw` analyzer gained `output_descriptor` / `kind` / `anchor` when #19 merged, but its `detects_real_ekf_selector_whipsaw` snapshot was never regenerated — it still carried the old top-level `end_timestamp_us` and no descriptor block. `cargo test -p flight-review` fails on it, leaving `main` red. This regenerates the snapshot to match the analyzer's current output (region `kind`, the `estimator_selector_status.instance_changed_count` anchor, and the typed field descriptor). No code change, snapshot only.

Second, while verifying CI I found the `Validate analyzers` step fails with zero output on any diagnostics PR that touches only a snapshot or fixture (no analyzer `.rs`). In `--changed-only` mode the script extracts analyzer names via `... | grep -v -E '^(mod|testing)$' | ...`; when nothing matches, `grep` exits 1, and under `set -e` + `pipefail` the whole script aborts before its own "no analyzer files changed" early-exit. Guarding the grep with `|| true` fixes it. This is a pre-existing CI bug, not introduced here — it just happened to bite this snapshot-only change.

The full converter suite passes and `check-analyzer.sh` now exits 0 in both the snapshot-only and analyzer-changed cases.
