### PR TITLE
ci(docker): only build the image on PRs that touch build inputs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,10 +1,19 @@
 name: Docker
 
 on:
-  push:
-    branches: [main]
+  # Only run when something that actually affects the image changes. The build
+  # is the slowest job in CI (~8 min, full workspace recompile) and the image
+  # is built-and-discarded on PRs (push: false), so running it on every change
+  # was wasted time. release.yml still builds and publishes on version tags.
   pull_request:
     branches: [main]
+    paths:
+      - 'Dockerfile'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**'
+      - '.github/workflows/docker.yml'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
The Docker Build job is the slowest thing in CI — a median ~8 minutes, about 2.5x the next slowest job — and it ran on every push and pull request to `main` with no path filters. The Dockerfile copies the whole `crates/` tree before running `cargo build --release` of a 429-dependency workspace, so any source change busts the cargo layer and forces a full recompile; the `type=gha` cache can only restore base/apt layers, never the compile, which is why the time stays flat regardless of branch. On PRs the image is built and immediately discarded (`push: false`) — only `release.yml` publishes, and only on version tags.

This scopes the `pull_request` trigger to the paths that actually affect the image (`Dockerfile`, `Cargo.toml`, `Cargo.lock`, `crates/**`, and this workflow) and drops the push-to-`main` trigger entirely, plus adds `workflow_dispatch` for manual runs. PRs that don't touch the build no longer pay the ~8 minutes. Dockerfile/build regressions are still caught on any PR that changes those inputs, and `release.yml` still builds and publishes the image on tags.

One thing to check before merging: if "Docker Build" is currently a required status check in branch protection, path-filtering it will block merges on PRs that don't touch those paths (the check never reports). It needs to be made non-required first.
