### PR TITLE
fix(viewer): tidy summary header and make plots shrink with the viewport

### DIFF
--- a/frontend/src/lib/components/viewer/FlightSummaryHeader.svelte
+++ b/frontend/src/lib/components/viewer/FlightSummaryHeader.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { FlightMetadata } from '$lib/types';
-	import { formatDuration, parseFlightDateFromFilename, formatFlightDateTime } from '$lib/utils/formatters';
+	import { formatDuration, parseFlightDateFromFilename, formatRelativeTime } from '$lib/utils/formatters';
 	import { getHardwareName } from '$lib/utils/hardwareNames';
 
 	let { metadata, logId, vehicleType, locationName, filename, createdAt } = $props<{ metadata: FlightMetadata; logId: string; vehicleType?: string | null; locationName?: string | null; filename?: string | null; createdAt?: string | null }>();
@@ -15,7 +15,7 @@
 		}
 		return null;
 	});
-	const flightDateParts = $derived(flightDate ? formatFlightDateTime(flightDate.date) : null);
+	const flightDateRelative = $derived(flightDate ? formatRelativeTime(flightDate.date.toISOString()) : null);
 	const flightDateLabel = $derived(flightDate?.source === 'upload' ? 'Uploaded' : 'Flight Date');
 	const flightDateTooltip = $derived(flightDate ? flightDate.date.toLocaleString() : '');
 
@@ -97,18 +97,18 @@
 					{#if location.city}<dd class="text-[10px] text-gray-500 whitespace-nowrap">{location.city}</dd>{/if}
 				</div>
 			{:else}
-				<svg class="size-4 text-gray-300" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+				<svg class="size-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" role="img" aria-label="No location data">
+					<title>No location data</title>
 					<path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" />
 					<path stroke-linecap="round" stroke-linejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z" />
 					<path stroke-linecap="round" stroke-linejoin="round" d="M3 3l18 18" />
 				</svg>
-				<dd class="text-xs text-gray-400 whitespace-nowrap">No Location</dd>
 			{/if}
 		</div>
-		{#if flightDateParts}
+		{#if flightDateRelative}
 			<div class="shrink-0 px-3 py-1.5" title={flightDateTooltip}>
 				<dt class="text-[10px] text-gray-500">{flightDateLabel}</dt>
-				<dd class="text-xs font-medium text-gray-700 whitespace-nowrap">{flightDateParts.date} <span class="text-gray-500">{flightDateParts.time}</span></dd>
+				<dd class="text-xs font-medium text-gray-700 whitespace-nowrap">{flightDateRelative}</dd>
 			</div>
 		{/if}
 		<div class="shrink-0 px-3 py-1.5">
@@ -161,13 +161,13 @@
 			</a>
 		</div>
 	</dl>
-	<!-- Desktop: flex layout -->
-	<dl class="hidden lg:flex lg:divide-x divide-gray-200 lg:px-0">
-		<div class="px-2 lg:px-4 py-2 lg:py-3 flex items-center gap-3">
+	<!-- Desktop: flex layout, scrolls horizontally when it can't all fit -->
+	<dl class="hidden lg:flex overflow-x-auto lg:divide-x divide-gray-200 lg:px-0 scrollbar-none">
+		<div class="shrink-0 px-2 lg:px-4 py-2 lg:py-3 flex items-center gap-3">
 			<img src={vehicleIconPath(vehicleType)} alt={vehicleType ?? ''} class="size-10 opacity-70" />
 			<dd class="text-sm font-semibold text-gray-900 whitespace-nowrap">{vehicleType ?? metadata.sys_name ?? '\u2014'}</dd>
 		</div>
-		<div class="px-2 lg:px-4 py-2 lg:py-3 flex items-center gap-2">
+		<div class="shrink-0 px-2 lg:px-4 py-2 lg:py-3 flex items-center gap-2">
 			{#if location}
 				{#if location.flag}<span class="text-2xl">{location.flag}</span>{/if}
 				<div class="flex flex-col">
@@ -175,50 +175,50 @@
 					{#if location.city}<dd class="text-xs text-gray-500 whitespace-nowrap">{location.city}</dd>{/if}
 				</div>
 			{:else}
-				<svg class="size-5 text-gray-300" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+				<svg class="size-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" role="img" aria-label="No location data">
+					<title>No location data</title>
 					<path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" />
 					<path stroke-linecap="round" stroke-linejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z" />
 					<path stroke-linecap="round" stroke-linejoin="round" d="M3 3l18 18" />
 				</svg>
-				<dd class="text-sm text-gray-400 whitespace-nowrap">No Location</dd>
 			{/if}
 		</div>
-		{#if flightDateParts}
-			<div class="px-2 lg:px-4 py-2 lg:py-3" title={flightDateTooltip}>
-				<dt class="text-xs text-gray-500">{flightDateLabel}</dt>
-				<dd class="text-sm font-medium text-gray-700 mt-0.5 whitespace-nowrap">{flightDateParts.date} <span class="text-gray-500">{flightDateParts.time}</span></dd>
+		{#if flightDateRelative}
+			<div class="shrink-0 px-2 lg:px-4 py-2 lg:py-3" title={flightDateTooltip}>
+				<dt class="text-xs text-gray-500 whitespace-nowrap">{flightDateLabel}</dt>
+				<dd class="text-sm font-medium text-gray-700 mt-0.5 whitespace-nowrap">{flightDateRelative}</dd>
 			</div>
 		{/if}
-		<div class="px-2 lg:px-4 py-2 lg:py-3">
-			<dt class="text-xs text-gray-500">Hardware</dt>
-			<dd class="text-sm font-medium text-gray-700 mt-0.5 truncate" title={metadata.ver_hw ?? ''}>{getHardwareName(metadata.ver_hw)}</dd>
+		<div class="shrink-0 px-2 lg:px-4 py-2 lg:py-3">
+			<dt class="text-xs text-gray-500 whitespace-nowrap">Hardware</dt>
+			<dd class="text-sm font-medium text-gray-700 mt-0.5 whitespace-nowrap" title={metadata.ver_hw ?? ''}>{getHardwareName(metadata.ver_hw)}</dd>
 		</div>
-		<div class="px-2 lg:px-4 py-2 lg:py-3">
-			<dt class="text-xs text-gray-500">Firmware</dt>
-			<dd class="text-sm font-medium text-gray-700 mt-0.5 truncate">{metadata.ver_sw_release_str ?? '\u2014'}</dd>
+		<div class="shrink-0 px-2 lg:px-4 py-2 lg:py-3">
+			<dt class="text-xs text-gray-500 whitespace-nowrap">Firmware</dt>
+			<dd class="text-sm font-medium text-gray-700 mt-0.5 whitespace-nowrap">{metadata.ver_sw_release_str ?? '\u2014'}</dd>
 		</div>
-		<div class="px-2 lg:px-4 py-2 lg:py-3">
-			<dt class="text-xs text-gray-500">Duration</dt>
-			<dd class="text-sm font-semibold text-gray-900 mt-0.5">{formatDuration(metadata.flight_duration_s)}</dd>
+		<div class="shrink-0 px-2 lg:px-4 py-2 lg:py-3">
+			<dt class="text-xs text-gray-500 whitespace-nowrap">Duration</dt>
+			<dd class="text-sm font-semibold text-gray-900 mt-0.5 whitespace-nowrap">{formatDuration(metadata.flight_duration_s)}</dd>
 		</div>
-		<div class="px-2 lg:px-4 py-2 lg:py-3">
-			<dt class="text-xs text-gray-500">Distance</dt>
-			<dd class="text-sm font-medium text-gray-700 mt-0.5">{formatDistance(stats?.total_distance_m)}</dd>
+		<div class="shrink-0 px-2 lg:px-4 py-2 lg:py-3">
+			<dt class="text-xs text-gray-500 whitespace-nowrap">Distance</dt>
+			<dd class="text-sm font-medium text-gray-700 mt-0.5 whitespace-nowrap">{formatDistance(stats?.total_distance_m)}</dd>
 		</div>
-		<div class="px-2 lg:px-4 py-2 lg:py-3">
-			<dt class="text-xs text-gray-500">Max Alt</dt>
-			<dd class="text-sm font-medium text-gray-700 mt-0.5">{formatAltitude(stats?.max_altitude_diff_m)}</dd>
+		<div class="shrink-0 px-2 lg:px-4 py-2 lg:py-3">
+			<dt class="text-xs text-gray-500 whitespace-nowrap">Max Alt</dt>
+			<dd class="text-sm font-medium text-gray-700 mt-0.5 whitespace-nowrap">{formatAltitude(stats?.max_altitude_diff_m)}</dd>
 		</div>
-		<div class="px-2 lg:px-4 py-2 lg:py-3">
-			<dt class="text-xs text-gray-500">Max Speed</dt>
-			<dd class="text-sm font-medium text-gray-700 mt-0.5">{formatSpeed(stats?.max_speed_m_s)}</dd>
+		<div class="shrink-0 px-2 lg:px-4 py-2 lg:py-3">
+			<dt class="text-xs text-gray-500 whitespace-nowrap">Max Speed</dt>
+			<dd class="text-sm font-medium text-gray-700 mt-0.5 whitespace-nowrap">{formatSpeed(stats?.max_speed_m_s)}</dd>
 		</div>
-		<div class="px-2 lg:px-4 py-2 lg:py-3">
-			<dt class="text-xs text-gray-500">Battery</dt>
-			<dd class="text-sm font-medium text-gray-700 mt-0.5">{formatBattery(battery?.discharged_mah)}</dd>
+		<div class="shrink-0 px-2 lg:px-4 py-2 lg:py-3">
+			<dt class="text-xs text-gray-500 whitespace-nowrap">Battery</dt>
+			<dd class="text-sm font-medium text-gray-700 mt-0.5 whitespace-nowrap">{formatBattery(battery?.discharged_mah)}</dd>
 		</div>
-		<div class="px-2 lg:px-4 py-2 lg:py-3">
-			<dt class="text-xs text-gray-500">Vibration</dt>
+		<div class="shrink-0 px-2 lg:px-4 py-2 lg:py-3">
+			<dt class="text-xs text-gray-500 whitespace-nowrap">Vibration</dt>
 			<dd class="mt-0.5">
 				{#if vibe.bg}
 					<span class="inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium {vibe.bg} {vibe.fg}">{vibe.text}</span>
@@ -227,13 +227,13 @@
 				{/if}
 			</dd>
 		</div>
-		<div class="px-2 lg:px-4 py-2 lg:py-3">
-			<dt class="text-xs text-gray-500">GPS</dt>
-			<dd class="text-sm font-medium text-gray-700 mt-0.5">
+		<div class="shrink-0 px-2 lg:px-4 py-2 lg:py-3">
+			<dt class="text-xs text-gray-500 whitespace-nowrap">GPS</dt>
+			<dd class="text-sm font-medium text-gray-700 mt-0.5 whitespace-nowrap">
 				{gps?.max_satellites != null ? `${gps.max_satellites} sats` : '\u2014'}
 			</dd>
 		</div>
-		<div class="px-2 lg:px-4 py-2 lg:py-3 flex items-end">
+		<div class="shrink-0 px-2 lg:px-4 py-2 lg:py-3 flex items-end">
 			<a
 				href="/api/logs/{logId}/download"
 				class="rounded-md bg-white px-3 py-1.5 text-xs font-medium text-gray-700 ring-1 ring-gray-300 hover:bg-gray-50 flex items-center gap-1.5"

--- a/frontend/src/lib/components/viewer/PlotStrip.svelte
+++ b/frontend/src/lib/components/viewer/PlotStrip.svelte
@@ -27,6 +27,12 @@
 	let uplot: uPlot | null = null;
 	let resizeObserver: ResizeObserver | null = null;
 
+	// The chart's available width, from the element uPlot renders into. clientWidth
+	// is post-layout and excludes scrollbars, so the plot never exceeds its column.
+	function measuredWidth(): number {
+		return chartEl?.clientWidth || containerEl?.clientWidth || 800;
+	}
+
 	let loading = $state(true);
 	let error = $state<string | null>(null);
 	let plotHeight = $state(300);
@@ -86,7 +92,9 @@
 
 			const data: uPlot.AlignedData = [result.timestamps, ...result.series];
 
-			const containerWidth = containerEl?.clientWidth ?? 800;
+			// clientWidth is the post-layout, clip-aware inner width, so the plot
+			// is never created wider than the column actually allows.
+			const containerWidth = measuredWidth();
 			plotHeight = containerWidth < 640 ? 180 : 300;
 
 			// Destroy previous chart if any
@@ -154,6 +162,18 @@
 
 			if (chartEl) {
 				uplot = new uPlot(opts, data, chartEl);
+				// Layout may still be settling when the chart is first created
+				// (async data load can resolve before the column reaches its
+				// final width). Re-measure on the next frame and correct, so the
+				// plot never stays wider than its container.
+				requestAnimationFrame(() => {
+					if (!uplot) return;
+					const w = measuredWidth();
+					if (w > 0 && w !== uplot.width) {
+						plotHeight = w < 640 ? 180 : 300;
+						uplot.setSize({ width: w, height: plotHeight });
+					}
+				});
 			}
 
 			loading = false;

--- a/frontend/src/lib/components/viewer/TrajectoryPlot.svelte
+++ b/frontend/src/lib/components/viewer/TrajectoryPlot.svelte
@@ -143,7 +143,11 @@
 		lastWidth = cssW;
 		const cssH = plotHeight;
 
-		canvas.style.width = `${cssW}px`;
+		// Don't set canvas.style.width — the `w-full` class sizes the canvas
+		// from layout. Pinning an explicit px width here props the container
+		// open and stops it from ever shrinking (the ResizeObserver would
+		// then never see a smaller width). Only the backing store and height
+		// are set imperatively.
 		canvas.style.height = `${cssH}px`;
 		canvas.width = Math.floor(cssW * dpr);
 		canvas.height = Math.floor(cssH * dpr);

--- a/frontend/src/routes/log/[id]/+layout.svelte
+++ b/frontend/src/routes/log/[id]/+layout.svelte
@@ -194,8 +194,8 @@
 		</div>
 
 		<!-- Main area: content -->
-		<div class="flex flex-1 {activeTab === '/map' ? 'min-h-0 overflow-hidden' : ''}">
-			<div class="flex-1 flex flex-col {activeTab === '/map' ? 'min-h-0 overflow-hidden' : ''}">
+		<div class="flex flex-1 min-w-0 {activeTab === '/map' ? 'min-h-0 overflow-hidden' : ''}">
+			<div class="flex-1 flex flex-col min-w-0 {activeTab === '/map' ? 'min-h-0 overflow-hidden' : ''}">
 				<!-- Panel content (from child route) -->
 				<div class="{activeTab === '/map' ? 'flex-1 flex flex-col min-h-0' : ''} p-3 sm:p-4 space-y-4 overflow-x-hidden">
 					{@render children()}


### PR DESCRIPTION
Two small fixes to the log viewer's layout, verified in the browser against real logs.

The sticky flight-summary header bar squeezed its columns into each other at narrower widths — the vehicle name collided with the location block and stat labels wrapped to two lines. Columns are now `shrink-0` with nowrap labels so the bar scrolls horizontally instead of mangling content, the no-location state collapses to just the pin icon instead of a wide "No Location" label, and the upload date shows as relative time with the full timestamp on hover. Side-scrolling on a few logs at some widths is a better trade than overflowing text and wasted space.

The plots also only ever grew with the window and never shrank back, overflowing the viewport (clipped by `overflow-x-hidden`) when it narrowed. Root cause was a flexbox `min-width: auto` trap: the content column refused to shrink below the plots' intrinsic width, so each plot's `ResizeObserver` never saw a smaller width. Adding `min-w-0` to the content column fixes it, and the plots no longer size themselves wider than that column (TrajectoryPlot drops its imperative canvas width in favor of `w-full`; PlotStrip measures from `clientWidth` and re-measures once after uPlot is created). Verified plots track the viewport in both directions from 1000px to 2400px with no horizontal scroll.

Frontend `svelte-check` passes with no errors. No backend changes.
