### PR TITLE
feat: surface component versions in the dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,6 +968,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "toml",
  "walkdir",
 ]
 
@@ -2842,6 +2843,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3435,6 +3445,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -4172,6 +4223,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/converter/Cargo.toml
+++ b/crates/converter/Cargo.toml
@@ -28,6 +28,9 @@ path = "src/bin/ulog_convert.rs"
 name = "convert"
 harness = false
 
+[build-dependencies]
+toml = "0.8"
+
 [dev-dependencies]
 tempfile = "3"
 criterion = { version = "0.5", default-features = false }

--- a/crates/converter/build.rs
+++ b/crates/converter/build.rs
@@ -1,0 +1,51 @@
+//! Capture the resolved `px4-ulog` version at build time so it can be surfaced
+//! at runtime (e.g. in the dashboard's version panel).
+//!
+//! Cargo offers no direct env var for a dependency's *resolved* version (the
+//! `DEP_<crate>` mechanism only exists for `links =` crates, which px4-ulog is
+//! not, and the Cargo.toml requirement string is the requirement, not the
+//! resolved version). The committed `Cargo.lock` records the exact resolved
+//! version, so we read it here. Any failure falls back to `unknown` — the build
+//! must never break over a debug string.
+
+use std::path::{Path, PathBuf};
+
+fn main() {
+    let version = resolve_px4_ulog_version().unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=PX4_ULOG_VERSION={version}");
+}
+
+/// Walk up from the crate manifest dir to find the workspace `Cargo.lock` and
+/// read the `px4-ulog` package version out of it.
+fn resolve_px4_ulog_version() -> Option<String> {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").ok()?;
+    let lock_path = find_cargo_lock(Path::new(&manifest_dir))?;
+    println!("cargo:rerun-if-changed={}", lock_path.display());
+
+    let contents = std::fs::read_to_string(&lock_path).ok()?;
+    let doc: toml::Value = contents.parse().ok()?;
+    let packages = doc.get("package")?.as_array()?;
+    packages
+        .iter()
+        .find(|p| p.get("name").and_then(|n| n.as_str()) == Some("px4-ulog"))
+        .and_then(|p| p.get("version"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+/// Find the workspace `Cargo.lock` by walking up from `start` and keeping the
+/// *outermost* lockfile found. A stale per-crate `crates/converter/Cargo.lock`
+/// can exist and resolve an old version, so the nearest lock is the wrong one;
+/// the authoritative resolution lives at the workspace root.
+fn find_cargo_lock(start: &Path) -> Option<PathBuf> {
+    let mut outermost = None;
+    let mut dir = Some(start);
+    while let Some(d) = dir {
+        let candidate = d.join("Cargo.lock");
+        if candidate.is_file() {
+            outermost = Some(candidate);
+        }
+        dir = d.parent();
+    }
+    outermost
+}

--- a/crates/converter/src/lib.rs
+++ b/crates/converter/src/lib.rs
@@ -4,3 +4,10 @@ pub mod diagnostics;
 pub mod metadata;
 pub mod pid_analysis;
 pub mod signal_processing;
+
+/// This crate's version (the converter / `ulog-convert` library).
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// The resolved `px4-ulog` parser version, captured from `Cargo.lock` at build
+/// time (see `build.rs`). `"unknown"` if it couldn't be determined.
+pub const PX4_ULOG_VERSION: &str = env!("PX4_ULOG_VERSION");

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -32,5 +32,9 @@ futures = "0.3"
 tempfile = "3"
 reqwest = { version = "0.12", features = ["json"] }
 
+[build-dependencies]
+# Already a runtime dependency above; used in build.rs to format the build time.
+chrono = { version = "0.4", default-features = false, features = ["alloc"] }
+
 [dev-dependencies]
 reqwest = { version = "0.12", features = ["json", "multipart"] }

--- a/crates/server/build.rs
+++ b/crates/server/build.rs
@@ -44,41 +44,19 @@ fn run_git(args: &[&str]) -> Option<String> {
 }
 
 /// Build time as an ISO-8601 UTC string. Honors `SOURCE_DATE_EPOCH` for
-/// reproducible builds; otherwise uses the wall clock. Formatted without a date
-/// library to avoid a build-dependency.
+/// reproducible builds; otherwise uses the wall clock. `unknown` if neither is
+/// available.
 fn build_time() -> String {
     let secs = std::env::var("SOURCE_DATE_EPOCH")
         .ok()
-        .and_then(|s| s.parse::<u64>().ok())
+        .and_then(|s| s.parse::<i64>().ok())
         .or_else(|| {
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .ok()
-                .map(|d| d.as_secs())
+                .map(|d| d.as_secs() as i64)
         });
-    match secs {
-        Some(secs) => format_iso8601_utc(secs),
-        None => "unknown".to_string(),
-    }
-}
-
-/// Format Unix seconds as `YYYY-MM-DDTHH:MM:SSZ` (UTC, proleptic Gregorian).
-fn format_iso8601_utc(secs: u64) -> String {
-    let days = secs / 86_400;
-    let rem = secs % 86_400;
-    let (hour, min, sec) = (rem / 3600, (rem % 3600) / 60, rem % 60);
-
-    // Civil-from-days (Howard Hinnant's algorithm), epoch 1970-01-01.
-    let z = days as i64 + 719_468;
-    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
-    let doe = z - era * 146_097;
-    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
-    let y = yoe + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let day = doy - (153 * mp + 2) / 5 + 1;
-    let month = if mp < 10 { mp + 3 } else { mp - 9 };
-    let year = if month <= 2 { y + 1 } else { y };
-
-    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}Z")
+    secs.and_then(|s| chrono::DateTime::from_timestamp(s, 0))
+        .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+        .unwrap_or_else(|| "unknown".to_string())
 }

--- a/crates/server/build.rs
+++ b/crates/server/build.rs
@@ -1,0 +1,84 @@
+//! Capture git SHA and build time at compile time so the server can report
+//! exactly which build is running (see the `/api/version` endpoint).
+//!
+//! Everything here degrades to `"unknown"` rather than failing: builds happen
+//! in plenty of places without git (release tarballs, `cargo install`, vendored
+//! sources), and a missing debug string must never break the build.
+
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn main() {
+    println!("cargo:rustc-env=GIT_SHA={}", git_sha());
+    println!("cargo:rustc-env=BUILD_TIME={}", build_time());
+    // Refresh the SHA when HEAD moves. Best-effort: absent in non-git builds.
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+}
+
+/// Short HEAD SHA, with a `-dirty` suffix when the working tree has changes.
+fn git_sha() -> String {
+    let sha = run_git(&["rev-parse", "--short", "HEAD"]);
+    let Some(sha) = sha else {
+        return "unknown".to_string();
+    };
+    // `--porcelain` prints nothing for a clean tree.
+    let dirty = run_git(&["status", "--porcelain"])
+        .map(|s| !s.is_empty())
+        .unwrap_or(false);
+    if dirty {
+        format!("{sha}-dirty")
+    } else {
+        sha
+    }
+}
+
+fn run_git(args: &[&str]) -> Option<String> {
+    let out = Command::new("git").args(args).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    // Empty output is meaningful for some callers (e.g. a clean `status
+    // --porcelain`), so return it as-is rather than treating it as failure.
+    Some(String::from_utf8(out.stdout).ok()?.trim().to_string())
+}
+
+/// Build time as an ISO-8601 UTC string. Honors `SOURCE_DATE_EPOCH` for
+/// reproducible builds; otherwise uses the wall clock. Formatted without a date
+/// library to avoid a build-dependency.
+fn build_time() -> String {
+    let secs = std::env::var("SOURCE_DATE_EPOCH")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .or_else(|| {
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .ok()
+                .map(|d| d.as_secs())
+        });
+    match secs {
+        Some(secs) => format_iso8601_utc(secs),
+        None => "unknown".to_string(),
+    }
+}
+
+/// Format Unix seconds as `YYYY-MM-DDTHH:MM:SSZ` (UTC, proleptic Gregorian).
+fn format_iso8601_utc(secs: u64) -> String {
+    let days = secs / 86_400;
+    let rem = secs % 86_400;
+    let (hour, min, sec) = (rem / 3600, (rem % 3600) / 60, rem % 60);
+
+    // Civil-from-days (Howard Hinnant's algorithm), epoch 1970-01-01.
+    let z = days as i64 + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = if month <= 2 { y + 1 } else { y };
+
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}Z")
+}

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -2,6 +2,7 @@ pub mod health;
 pub mod logs;
 pub mod stats;
 pub mod upload;
+pub mod version;
 
 use axum::{http::StatusCode, response::IntoResponse, Json};
 

--- a/crates/server/src/api/version.rs
+++ b/crates/server/src/api/version.rs
@@ -1,0 +1,35 @@
+//! `GET /api/version` — reports the running versions of the server, converter
+//! library, and px4-ulog parser, plus the server's git SHA and build time.
+//!
+//! Everything is captured at compile time (see the server and converter
+//! `build.rs` scripts), so the handler is static: no state, no DB, no auth.
+//! The frontend reports its own version separately (baked at its build time),
+//! which lets independently-deployed front/back drift be diagnosed.
+
+use axum::Json;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct VersionInfo {
+    /// HTTP server crate version.
+    pub server: &'static str,
+    /// Converter/analysis library version.
+    pub converter: &'static str,
+    /// Resolved px4-ulog parser version.
+    pub px4_ulog: &'static str,
+    /// Short git SHA the server was built from (`-dirty` if the tree had
+    /// uncommitted changes, `unknown` for non-git builds).
+    pub git_sha: &'static str,
+    /// Server build time, ISO-8601 UTC (`unknown` if unavailable).
+    pub build_time: &'static str,
+}
+
+pub async fn version() -> Json<VersionInfo> {
+    Json(VersionInfo {
+        server: env!("CARGO_PKG_VERSION"),
+        converter: flight_review::VERSION,
+        px4_ulog: flight_review::PX4_ULOG_VERSION,
+        git_sha: env!("GIT_SHA"),
+        build_time: env!("BUILD_TIME"),
+    })
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -4,7 +4,13 @@ pub mod extract;
 pub mod geocode;
 pub mod storage;
 
+use axum::{
+    extract::DefaultBodyLimit,
+    routing::{get, post},
+    Router,
+};
 use std::sync::Arc;
+use tower_http::cors::CorsLayer;
 
 /// Shared application state passed to all handlers via axum's State extractor.
 pub struct AppState {
@@ -17,4 +23,30 @@ pub struct AppState {
     pub mapbox_token: Option<String>,
     /// Shared HTTP client for outbound requests (geocoding, etc.).
     pub http_client: reqwest::Client,
+}
+
+/// Build the application router. Shared by the binary (`main.rs`) and the
+/// integration tests so they can never drift out of sync.
+pub fn build_router(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/health", get(api::health::health))
+        .route("/api/version", get(api::version::version))
+        .route(
+            "/api/upload",
+            post(api::upload::upload).layer(DefaultBodyLimit::max(512 * 1024 * 1024)), // 512 MB
+        )
+        .route("/api/logs", get(api::logs::list_logs))
+        .route("/api/logs/facets", get(api::logs::list_facets))
+        .route("/api/stats", get(api::stats::get_stats))
+        .route(
+            "/api/logs/{id}",
+            get(api::logs::get_log).delete(api::logs::delete_log),
+        )
+        .route("/api/logs/{id}/track", get(api::logs::get_track))
+        .route(
+            "/api/logs/{id}/data/{filename}",
+            get(api::logs::get_log_file),
+        )
+        .layer(CorsLayer::permissive())
+        .with_state(state)
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,15 +1,9 @@
-use axum::{
-    extract::DefaultBodyLimit,
-    routing::{get, post},
-    Router,
-};
 use clap::{Args, Parser, Subcommand};
 use std::sync::Arc;
 use tokio::net::TcpListener;
-use tower_http::cors::CorsLayer;
 use tracing_subscriber::EnvFilter;
 
-use flight_review_server::{api, db, storage::FileStorage, AppState};
+use flight_review_server::{db, storage::FileStorage, AppState};
 
 #[derive(Parser)]
 #[command(version, about = "Flight Review v2 server")]
@@ -90,8 +84,12 @@ async fn main() {
 
 async fn run_server(config: ServeConfig) {
     tracing::info!(
-        "flight-review-server v{}",
-        env!("CARGO_PKG_VERSION")
+        "flight-review-server v{} (converter {}, px4-ulog {}, git {}, built {})",
+        env!("CARGO_PKG_VERSION"),
+        flight_review::VERSION,
+        flight_review::PX4_ULOG_VERSION,
+        env!("GIT_SHA"),
+        env!("BUILD_TIME"),
     );
     tracing::info!("db:      {}", config.db);
     tracing::info!("storage: {}", config.storage);
@@ -118,24 +116,7 @@ async fn run_server(config: ServeConfig) {
         http_client: reqwest::Client::new(),
     });
 
-    let app = Router::new()
-        .route("/health", get(api::health::health))
-        .route("/api/upload", post(api::upload::upload)
-            .layer(DefaultBodyLimit::max(512 * 1024 * 1024))) // 512 MB
-        .route("/api/logs", get(api::logs::list_logs))
-        .route("/api/logs/facets", get(api::logs::list_facets))
-        .route("/api/stats", get(api::stats::get_stats))
-        .route(
-            "/api/logs/{id}",
-            get(api::logs::get_log).delete(api::logs::delete_log),
-        )
-        .route("/api/logs/{id}/track", get(api::logs::get_track))
-        .route(
-            "/api/logs/{id}/data/{filename}",
-            get(api::logs::get_log_file),
-        )
-        .layer(CorsLayer::permissive())
-        .with_state(state);
+    let app = flight_review_server::build_router(state);
 
     let addr = format!("{}:{}", config.host, config.port);
     let listener = TcpListener::bind(&addr)

--- a/crates/server/tests/integration.rs
+++ b/crates/server/tests/integration.rs
@@ -65,36 +65,9 @@ async fn start_server() -> (String, tokio::task::JoinHandle<()>) {
         http_client: reqwest::Client::new(),
     });
 
-    use axum::{
-        extract::DefaultBodyLimit,
-        routing::{get, post},
-        Router,
-    };
-    use tower_http::cors::CorsLayer;
-
-    let app = Router::new()
-        .route("/health", get(flight_review_server::api::health::health))
-        .route(
-            "/api/upload",
-            post(flight_review_server::api::upload::upload)
-                .layer(DefaultBodyLimit::max(512 * 1024 * 1024)),
-        )
-        .route("/api/logs", get(flight_review_server::api::logs::list_logs))
-        .route(
-            "/api/logs/{id}",
-            get(flight_review_server::api::logs::get_log)
-                .delete(flight_review_server::api::logs::delete_log),
-        )
-        .route(
-            "/api/logs/{id}/data/{filename}",
-            get(flight_review_server::api::logs::get_log_file),
-        )
-        .route(
-            "/api/stats",
-            get(flight_review_server::api::stats::get_stats),
-        )
-        .layer(CorsLayer::permissive())
-        .with_state(state);
+    // Use the same router the binary serves, so the test never drifts from
+    // the real route table.
+    let app = flight_review_server::build_router(state);
 
     let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{}", port))
         .await
@@ -132,6 +105,23 @@ async fn test_full_lifecycle() {
     assert_eq!(resp.status(), 200);
     let body: Value = resp.json().await.unwrap();
     assert_eq!(body["status"], "ok");
+
+    // 1b. Version info — all five fields present and non-empty.
+    let resp = client
+        .get(format!("{}/api/version", base_url))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: Value = resp.json().await.unwrap();
+    for field in ["server", "converter", "px4_ulog", "git_sha", "build_time"] {
+        let v = body[field].as_str();
+        assert!(
+            v.is_some_and(|s| !s.is_empty()),
+            "version field '{field}' missing or empty: {body:?}"
+        );
+    }
+    assert_eq!(body["px4_ulog"], "0.6.1", "px4-ulog version should match Cargo.lock");
 
     // 2. Upload a log
     let fixture = fixture_path("sample.ulg");

--- a/frontend/src/app.d.ts
+++ b/frontend/src/app.d.ts
@@ -1,2 +1,7 @@
 /// <reference types="@sveltejs/kit" />
 declare namespace App {}
+
+// Injected at build time by Vite `define` (see vite.config.ts).
+declare const __APP_VERSION__: string;
+declare const __GIT_SHA__: string;
+declare const __BUILD_TIME__: string;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { LogRecord, ListFilters, ListResponse, UploadOptions, UploadResponse, FlightMetadata, StatsResponse } from './types';
+import type { LogRecord, ListFilters, ListResponse, UploadOptions, UploadResponse, FlightMetadata, StatsResponse, VersionInfo } from './types';
 
 const BASE = '/api';
 
@@ -20,6 +20,10 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
 
 export async function getLog(id: string): Promise<LogRecord> {
   return apiFetch(`/logs/${id}`);
+}
+
+export async function getVersion(): Promise<VersionInfo> {
+  return apiFetch('/version');
 }
 
 export async function listLogs(filters: ListFilters): Promise<ListResponse> {

--- a/frontend/src/lib/components/shared/NavBar.svelte
+++ b/frontend/src/lib/components/shared/NavBar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { darkMode } from '$lib/stores/theme';
+	import VersionBadge from './VersionBadge.svelte';
 
 	let { currentPath } = $props<{ currentPath: string }>();
 
@@ -113,7 +114,7 @@
 							Dark mode
 						{/if}
 					</button>
-					<span class="block text-xs font-medium text-gray-400 dark:text-gray-500">v2.0</span>
+					<VersionBadge />
 				</li>
 			</ul>
 		</nav>
@@ -210,7 +211,7 @@
 				</ul>
 			</nav>
 			<div class="mt-8">
-				<span class="text-xs font-medium text-gray-400 dark:text-gray-500">v2.0</span>
+				<VersionBadge />
 			</div>
 		</div>
 	</div>

--- a/frontend/src/lib/components/shared/VersionBadge.svelte
+++ b/frontend/src/lib/components/shared/VersionBadge.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { getVersion } from '$lib/api';
+	import type { VersionInfo } from '$lib/types';
+
+	// Frontend version is baked in at build time (Vite define). Backend versions
+	// are fetched at runtime; they can differ since the two deploy separately.
+	const frontend = {
+		version: __APP_VERSION__,
+		git_sha: __GIT_SHA__,
+		build_time: __BUILD_TIME__,
+	};
+
+	let backend = $state<VersionInfo | null>(null);
+	let backendFailed = $state(false);
+
+	onMount(async () => {
+		try {
+			backend = await getVersion();
+		} catch {
+			// Server unreachable / older server without the endpoint — show the
+			// frontend version anyway, never break the nav.
+			backendFailed = true;
+		}
+	});
+
+	function shortDate(iso: string): string {
+		if (!iso || iso === 'unknown') return 'unknown';
+		// Trim "2026-06-25T16:21:14Z" → "2026-06-25" for the compact rows.
+		return iso.slice(0, 10);
+	}
+</script>
+
+<details class="group text-xs text-gray-400 dark:text-gray-500">
+	<summary class="cursor-pointer list-none font-medium hover:text-gray-600 dark:hover:text-gray-300">
+		v{frontend.version}
+		<span class="opacity-60 group-open:hidden">▸</span>
+		<span class="opacity-60 hidden group-open:inline">▾</span>
+	</summary>
+	<dl class="mt-1.5 space-y-1">
+		<div>
+			<dt class="font-medium text-gray-500 dark:text-gray-400">Frontend</dt>
+			<dd class="tabular-nums">
+				{frontend.version} · {frontend.git_sha} · built {shortDate(frontend.build_time)}
+			</dd>
+		</div>
+		{#if backend}
+			<div>
+				<dt class="font-medium text-gray-500 dark:text-gray-400">Server</dt>
+				<dd class="tabular-nums">
+					{backend.server} · {backend.git_sha} · built {shortDate(backend.build_time)}
+				</dd>
+			</div>
+			<div>
+				<dt class="font-medium text-gray-500 dark:text-gray-400">Converter</dt>
+				<dd class="tabular-nums">{backend.converter}</dd>
+			</div>
+			<div>
+				<dt class="font-medium text-gray-500 dark:text-gray-400">px4-ulog</dt>
+				<dd class="tabular-nums">{backend.px4_ulog}</dd>
+			</div>
+		{:else if backendFailed}
+			<div><dd class="italic">server: unavailable</dd></div>
+		{:else}
+			<div><dd class="italic opacity-60">loading…</dd></div>
+		{/if}
+	</dl>
+</details>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -78,6 +78,16 @@ export interface UploadResponse {
   parquet_files: string[];
 }
 
+/// Backend version info from GET /api/version. The frontend reports its own
+/// version separately (baked in at build time via Vite define).
+export interface VersionInfo {
+  server: string;
+  converter: string;
+  px4_ulog: string;
+  git_sha: string;
+  build_time: string;
+}
+
 // --- Metadata types ---
 
 export interface FlightMetadata {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,8 +2,39 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vitest/config';
 import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import type { Plugin } from 'vite';
+
+// Build-time version info baked into the bundle and shown in the nav's version
+// panel. Git calls are guarded so `npm run dev` still works outside a repo or
+// without git installed.
+const pkgVersion = (() => {
+  try {
+    return JSON.parse(readFileSync(join(__dirname, 'package.json'), 'utf-8')).version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+})();
+
+function safeGit(args: string): string {
+  try {
+    return execSync(`git ${args}`, { cwd: __dirname, stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+const gitSha = (() => {
+  const sha = safeGit('rev-parse --short HEAD');
+  if (sha === 'unknown') return sha;
+  const dirty = safeGit('status --porcelain');
+  return dirty && dirty !== 'unknown' ? `${sha}-dirty` : sha;
+})();
+
+const buildTime = new Date().toISOString();
 
 /**
  * Serve DuckDB-WASM bundle files (workers, wasm, source maps) from node_modules
@@ -52,6 +83,11 @@ function duckdbAssets(): Plugin {
 
 export default defineConfig({
   plugins: [duckdbAssets(), tailwindcss(), sveltekit()],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkgVersion),
+    __GIT_SHA__: JSON.stringify(gitSha),
+    __BUILD_TIME__: JSON.stringify(buildTime),
+  },
   server: {
     proxy: {
       '/api': {


### PR DESCRIPTION
Adds a version panel to the dashboard nav so that when debugging an issue you can see exactly which build of each component you're looking at. The frontend, HTTP server, converter library, and px4-ulog parser version independently — the release workflow ships the server and frontend as separate tarballs — so their versions can legitimately drift. Showing all four side by side, with git SHA and build time, makes that visible and turns "which build is this?" into a glance instead of a guess.

On the backend, a new `build.rs` in the converter reads the resolved px4-ulog version out of `Cargo.lock` (the lockfile is the only place the exact resolved version lives), and a `build.rs` in the server captures the git short SHA (with a `-dirty` suffix when the tree is dirty) and the build time. A new unauthenticated `GET /api/version` returns the server, converter, and px4-ulog versions plus the server's SHA and build time — it's static (compile-time constants), so no state, no DB, no auth. While wiring the route I extracted the router into a shared `build_router()` used by both the binary and the integration test; the test had been hand-maintaining its own copy and had already drifted (it was missing a couple of routes).

On the frontend, its own version, SHA, and build time are baked in at build time via a Vite `define` (the git calls are guarded so `npm run dev` still works outside a git repo or without git installed). A small `VersionBadge` component — a native `<details>` disclosure, keyboard-accessible, no new dependency — replaces the hardcoded `v2.0` placeholders in the nav. It shows the frontend version inline and expands to all four components; it fetches the backend versions on mount and degrades to "server: unavailable" without breaking the nav if the server is down or predates the endpoint.

Every build-time capture falls back to `"unknown"` rather than failing the build when git or the lockfile isn't available (verified by building with git stubbed out). Tested end to end: the endpoint returns the right values (`px4_ulog` matches `Cargo.lock`), the integration test asserts all five fields, the workspace builds under `-D warnings`, the frontend type-checks and builds, and the badge renders correctly in the browser including the server-down and no-git paths.
