### PR TITLE
Add tecs_nonfinite_pitch analyzer

### DIFF
--- a/crates/converter/src/diagnostics/mod.rs
+++ b/crates/converter/src/diagnostics/mod.rs
@@ -22,12 +22,13 @@ pub mod ekf_selector_whipsaw;
 pub mod gps_interference;
 pub mod motor_failure;
 pub mod rc_loss;
+pub mod tecs_nonfinite_pitch;
 #[cfg(test)]
 pub mod testing;
 
 /// Current analysis version. Bump when the analyzer set changes to trigger
 /// reprocessing of historical logs.
-pub const ANALYSIS_VERSION: u32 = 2;
+pub const ANALYSIS_VERSION: u32 = 3;
 
 /// Whether a diagnostic marks an instant or spans a time window.
 ///
@@ -137,6 +138,16 @@ pub enum MotorFailureMode {
     LockedAtMax,
 }
 
+/// Which TECS field first went non-finite — typed discriminant.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TecsNonfinitePitchField {
+    /// `tecs_status.pitch_integ` — the integrator, where the NaN latches first.
+    PitchInteg,
+    /// `tecs_status.pitch_sp_rad` — the pitch setpoint the NaN propagates into.
+    PitchSpRad,
+}
+
 /// Typed evidence for each diagnostic kind.
 ///
 /// Every analyzer returns a specific variant — not a freeform map.
@@ -186,6 +197,13 @@ pub enum Evidence {
         switched_to_degraded: bool,
         /// combined_test_ratio of the primary instance at detection time.
         primary_instance_test_ratio: f32,
+    },
+    TecsNonfinitePitch {
+        /// Which field first went non-finite (integrator or setpoint).
+        field: TecsNonfinitePitchField,
+        /// True if `throttle_integ` was also non-finite at the same sample —
+        /// a sibling-channel sanity check that the whole TECS state corrupted.
+        throttle_integ_nonfinite: bool,
     },
 }
 
@@ -256,6 +274,7 @@ pub fn create_analyzers() -> Vec<Box<dyn Analyzer>> {
         Box::new(ekf_failure::EkfFailureAnalyzer::new()),
         Box::new(rc_loss::RcLossAnalyzer::new()),
         Box::new(ekf_selector_whipsaw::EkfSelectorWhipsawAnalyzer::new()),
+        Box::new(tecs_nonfinite_pitch::TecsNonfinitePitchAnalyzer::new()),
     ]
 }
 

--- a/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__tecs_nonfinite_pitch__tests__detects_real_tecs_nonfinite_pitch.snap
+++ b/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__tecs_nonfinite_pitch__tests__detects_real_tecs_nonfinite_pitch.snap
@@ -1,0 +1,38 @@
+---
+source: crates/converter/src/diagnostics/tecs_nonfinite_pitch.rs
+expression: diags
+---
+[
+  {
+    "id": "tecs_nonfinite_pitch",
+    "summary": "TECS pitch_integ became non-finite (NaN) at 1029.9s and never recovered — aircraft loses pitch control",
+    "severity": "critical",
+    "kind": {
+      "region": {
+        "end_timestamp_us": 1035319434
+      }
+    },
+    "timestamp_us": 1029918348,
+    "anchor": {
+      "topic": "tecs_status",
+      "field": "pitch_integ"
+    },
+    "descriptor": {
+      "fields": [
+        {
+          "name": "field",
+          "unit": "label"
+        },
+        {
+          "name": "throttle_integ_nonfinite",
+          "unit": "label"
+        }
+      ]
+    },
+    "evidence": {
+      "type": "TecsNonfinitePitch",
+      "field": "pitch_integ",
+      "throttle_integ_nonfinite": false
+    }
+  }
+]

--- a/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__tecs_nonfinite_pitch__tests__snapshot_sample_ulg.snap
+++ b/crates/converter/src/diagnostics/snapshots/flight_review__diagnostics__tecs_nonfinite_pitch__tests__snapshot_sample_ulg.snap
@@ -1,0 +1,5 @@
+---
+source: crates/converter/src/diagnostics/tecs_nonfinite_pitch.rs
+expression: diags
+---
+[]

--- a/crates/converter/src/diagnostics/tecs_nonfinite_pitch.rs
+++ b/crates/converter/src/diagnostics/tecs_nonfinite_pitch.rs
@@ -1,0 +1,276 @@
+//! Non-finite TECS pitch integrator/setpoint detection.
+//!
+//! Monitors `tecs_status` for the pitch integrator (`pitch_integ`) or pitch
+//! setpoint (`pitch_sp_rad`) becoming non-finite (NaN or +/-Inf). This is a
+//! real, recurring, flight-critical failure: once the pitch integrator latches
+//! a NaN it propagates into the pitch setpoint, the aircraft loses pitch
+//! control, and it sheds altitude until a pilot intervenes.
+//!
+//! TECS is a low-rate fixed-wing/VTOL topic, so a single `is_finite()` check
+//! per sample is cheap and fits inside the diagnostics budget.
+
+use super::{
+    parse_field, AnomalyKind, Analyzer, Diagnostic, Evidence, FieldUnit, OutputDescriptor,
+    PlotAnchor, Severity, TecsNonfinitePitchField,
+};
+use px4_ulog::stream_parser::model::DataMessage;
+
+const TOPIC: &str = "tecs_status";
+
+pub struct TecsNonfinitePitchAnalyzer {
+    /// Timestamp/field of the first non-finite sample, if any.
+    first_nonfinite: Option<(u64, TecsNonfinitePitchField)>,
+    /// Was the throttle integrator also non-finite at that sample?
+    throttle_integ_nonfinite: bool,
+    /// Last timestamp seen on the topic — becomes the region end.
+    last_timestamp: u64,
+}
+
+impl Default for TecsNonfinitePitchAnalyzer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TecsNonfinitePitchAnalyzer {
+    pub fn new() -> Self {
+        Self {
+            first_nonfinite: None,
+            throttle_integ_nonfinite: false,
+            last_timestamp: 0,
+        }
+    }
+}
+
+impl Analyzer for TecsNonfinitePitchAnalyzer {
+    fn id(&self) -> &str {
+        "tecs_nonfinite_pitch"
+    }
+
+    fn description(&self) -> &str {
+        "Non-finite TECS pitch integrator or setpoint"
+    }
+
+    fn required_topics(&self) -> &[&str] {
+        &[TOPIC]
+    }
+
+    fn on_message(&mut self, data: &DataMessage) {
+        if data.flattened_format.message_name.as_str() != TOPIC {
+            return;
+        }
+
+        let ts = data
+            .flattened_format
+            .timestamp_field
+            .as_ref()
+            .map(|tf| tf.parse_timestamp(data.data))
+            .unwrap_or(0);
+        self.last_timestamp = ts;
+
+        // Once latched, keep tracking the end timestamp but don't re-detect.
+        if self.first_nonfinite.is_some() {
+            return;
+        }
+
+        let pitch_integ = parse_field::<f32>(data, "pitch_integ");
+        let pitch_sp_rad = parse_field::<f32>(data, "pitch_sp_rad");
+
+        // Prefer pitch_integ as the originating field, since the NaN latches
+        // there first and propagates into the setpoint.
+        let field = match (pitch_integ, pitch_sp_rad) {
+            (Some(v), _) if !v.is_finite() => Some(TecsNonfinitePitchField::PitchInteg),
+            (_, Some(v)) if !v.is_finite() => Some(TecsNonfinitePitchField::PitchSpRad),
+            _ => None,
+        };
+
+        if let Some(field) = field {
+            self.throttle_integ_nonfinite = parse_field::<f32>(data, "throttle_integ")
+                .map(|v| !v.is_finite())
+                .unwrap_or(false);
+            self.first_nonfinite = Some((ts, field));
+        }
+    }
+
+    fn finish(self: Box<Self>) -> Vec<Diagnostic> {
+        let descriptor = self.output_descriptor();
+        let Some((ts, field)) = self.first_nonfinite else {
+            return vec![];
+        };
+
+        // Region runs from first detection to the last sample seen.
+        let end = self.last_timestamp.max(ts);
+        let field_name = match field {
+            TecsNonfinitePitchField::PitchInteg => "pitch_integ",
+            TecsNonfinitePitchField::PitchSpRad => "pitch_sp_rad",
+        };
+
+        vec![Diagnostic {
+            id: "tecs_nonfinite_pitch".to_string(),
+            summary: format!(
+                "TECS {} became non-finite (NaN) at {:.1}s and never recovered — aircraft loses pitch control",
+                field_name,
+                ts as f64 / 1_000_000.0,
+            ),
+            severity: Severity::Critical,
+            kind: AnomalyKind::Region { end_timestamp_us: end },
+            timestamp_us: ts,
+            anchor: PlotAnchor::new(TOPIC, "pitch_integ"),
+            descriptor,
+            evidence: Evidence::TecsNonfinitePitch {
+                field,
+                throttle_integ_nonfinite: self.throttle_integ_nonfinite,
+            },
+        }]
+    }
+
+    fn output_descriptor(&self) -> OutputDescriptor {
+        OutputDescriptor::new()
+            .field("field", FieldUnit::Label)
+            .field("throttle_integ_nonfinite", FieldUnit::Label)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diagnostics::testing::*;
+
+    fn tecs_msg(ts: u64, pitch_integ: f32, pitch_sp_rad: f32, throttle_integ: f32) -> (px4_ulog::stream_parser::model::FlattenedFormat, Vec<u8>) {
+        MessageBuilder::new("tecs_status")
+            .timestamp(ts)
+            .field_f32("pitch_integ", pitch_integ)
+            .field_f32("pitch_sp_rad", pitch_sp_rad)
+            .field_f32("throttle_integ", throttle_integ)
+            .build()
+    }
+
+    #[test]
+    fn no_false_positives_sample() {
+        assert_no_false_positives("sample.ulg", "tecs_nonfinite_pitch");
+    }
+
+    #[test]
+    fn detects_nonfinite_pitch_integ() {
+        let mut analyzer = TecsNonfinitePitchAnalyzer::new();
+
+        // Healthy samples.
+        for i in 0..5 {
+            let (fmt, data) = tecs_msg((i + 1) * 100_000, 0.01, 0.02, 0.5);
+            analyzer.on_message(&make_data_message(&fmt, &data));
+        }
+        // pitch_integ latches NaN.
+        let (fmt, data) = tecs_msg(600_000, f32::NAN, 0.02, 0.5);
+        analyzer.on_message(&make_data_message(&fmt, &data));
+        // ... and stays bad to end of log.
+        for i in 6..10 {
+            let (fmt, data) = tecs_msg((i + 1) * 100_000, f32::NAN, f32::NAN, 0.5);
+            analyzer.on_message(&make_data_message(&fmt, &data));
+        }
+
+        let diags = Box::new(analyzer).finish();
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Critical);
+        assert_eq!(diags[0].timestamp_us, 600_000);
+        match &diags[0].kind {
+            AnomalyKind::Region { end_timestamp_us } => assert_eq!(*end_timestamp_us, 1_000_000),
+            _ => panic!("expected Region"),
+        }
+        match &diags[0].evidence {
+            Evidence::TecsNonfinitePitch { field, .. } => {
+                assert_eq!(*field, TecsNonfinitePitchField::PitchInteg)
+            }
+            _ => panic!("expected TecsNonfinitePitch"),
+        }
+    }
+
+    #[test]
+    fn detects_nonfinite_pitch_setpoint() {
+        let mut analyzer = TecsNonfinitePitchAnalyzer::new();
+        let (fmt, data) = tecs_msg(100_000, 0.01, f32::INFINITY, 0.5);
+        analyzer.on_message(&make_data_message(&fmt, &data));
+
+        let diags = Box::new(analyzer).finish();
+        assert_eq!(diags.len(), 1);
+        match &diags[0].evidence {
+            Evidence::TecsNonfinitePitch { field, .. } => {
+                assert_eq!(*field, TecsNonfinitePitchField::PitchSpRad)
+            }
+            _ => panic!("expected TecsNonfinitePitch"),
+        }
+    }
+
+    #[test]
+    fn fires_once_not_per_sample() {
+        let mut analyzer = TecsNonfinitePitchAnalyzer::new();
+        for i in 0..20 {
+            let (fmt, data) = tecs_msg((i + 1) * 100_000, f32::NAN, f32::NAN, 0.5);
+            analyzer.on_message(&make_data_message(&fmt, &data));
+        }
+        let diags = Box::new(analyzer).finish();
+        assert_eq!(diags.len(), 1, "should fire exactly once for the first NaN");
+    }
+
+    #[test]
+    fn captures_throttle_integ_sibling() {
+        let mut analyzer = TecsNonfinitePitchAnalyzer::new();
+        let (fmt, data) = tecs_msg(100_000, f32::NAN, 0.02, f32::NAN);
+        analyzer.on_message(&make_data_message(&fmt, &data));
+        let diags = Box::new(analyzer).finish();
+        match &diags[0].evidence {
+            Evidence::TecsNonfinitePitch { throttle_integ_nonfinite, .. } => {
+                assert!(*throttle_integ_nonfinite)
+            }
+            _ => panic!("expected TecsNonfinitePitch"),
+        }
+    }
+
+    #[test]
+    fn no_detection_when_finite() {
+        let mut analyzer = TecsNonfinitePitchAnalyzer::new();
+        for i in 0..20 {
+            let (fmt, data) = tecs_msg((i + 1) * 100_000, 0.01, 0.02, 0.5);
+            analyzer.on_message(&make_data_message(&fmt, &data));
+        }
+        let diags = Box::new(analyzer).finish();
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn handles_missing_fields() {
+        let mut analyzer = TecsNonfinitePitchAnalyzer::new();
+        let (fmt, data) = MessageBuilder::new("tecs_status")
+            .timestamp(1_000_000)
+            .build();
+        analyzer.on_message(&make_data_message(&fmt, &data)); // must not panic
+        let diags = Box::new(analyzer).finish();
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn snapshot_sample_ulg() {
+        let diags = analyze_fixture_for("sample.ulg", "tecs_nonfinite_pitch");
+        insta::assert_json_snapshot!(diags);
+    }
+
+    #[test]
+    fn detects_real_tecs_nonfinite_pitch() {
+        // Real PX4 FMU_V6X fixed-wing log where the TECS pitch integrator
+        // latched NaN in flight. Sourced from the public PX4 log corpus.
+        let diags = analyze_fixture_for("tecs_nonfinite_pitch.ulg", "tecs_nonfinite_pitch");
+        assert_eq!(
+            diags.len(),
+            1,
+            "should detect exactly one non-finite TECS pitch event"
+        );
+        assert_eq!(diags[0].severity, Severity::Critical);
+        assert!(matches!(diags[0].kind, AnomalyKind::Region { .. }));
+        match &diags[0].evidence {
+            Evidence::TecsNonfinitePitch { field, .. } => {
+                assert_eq!(*field, TecsNonfinitePitchField::PitchInteg)
+            }
+            _ => panic!("expected TecsNonfinitePitch evidence"),
+        }
+        insta::assert_json_snapshot!(diags);
+    }
+}

--- a/crates/converter/tests/fixtures/tecs_nonfinite_pitch.ulg
+++ b/crates/converter/tests/fixtures/tecs_nonfinite_pitch.ulg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50d8e5a4ee8d9442c6c12b043565aa59f60f63136f81e210e4e693649d3718b9
+size 844320


### PR DESCRIPTION
Adds a diagnostic analyzer that detects when the TECS pitch integrator or pitch setpoint becomes non-finite (NaN/Inf) in fixed-wing and VTOL logs, closing #30. This is a real, recurring, flight-critical failure: once `pitch_integ` latches a NaN it propagates into `pitch_sp_rad`, the aircraft loses pitch control and sheds altitude until a pilot intervenes.

The analyzer subscribes to `tecs_status`, flags the first sample where `pitch_integ` or `pitch_sp_rad` is non-finite, and emits a Critical Region diagnostic spanning from that sample to the end of the log, anchored on `tecs_status.pitch_integ`. It prefers `pitch_integ` as the originating field since the NaN latches there first, and records whether `throttle_integ` was also non-finite at the same sample as a sibling-channel sanity check. `tecs_status` is a low-rate topic, so the per-sample `is_finite()` check is cheap and stays well inside the diagnostics budget.

Coverage includes synthetic unit tests for both fields, single-fire (not per-sample), missing-field, and clean-log cases, plus a real-world fixture pulled from the public PX4 log corpus that exercises the actual `pitch_integ` latch. 

`ANALYSIS_VERSION` is bumped to 3 to trigger reprocessing of historical logs. No frontend or server changes are needed since diagnostics render off the self-describing output descriptor.

To find a real example I scanned the multicopter-only local corpus (zero `tecs_status` topics, as expected), then pulled the top fixed-wing/VTOL candidates from the public log index and found 8 logs exhibiting the failure in the first batch of 1000.

The eight logs found, all viewable in Flight Review:

- https://logs.px4.io/plot_app?log=c46c5d55-8e44-4d42-ae83-e9d528b4679c (`pitch_integ`)
- https://logs.px4.io/plot_app?log=dbf71f93-62bb-4e42-a8e0-ab752dd2beae (`pitch_integ`)
- https://logs.px4.io/plot_app?log=c4c9c6a3-5687-4e03-a5e8-8713c72b65c1 (`pitch_integ`)
- https://logs.px4.io/plot_app?log=ca73f867-9796-454c-b8dd-194cdf2f0115 (`pitch_integ`)
- https://logs.px4.io/plot_app?log=9277f0b7-d474-4e53-81f7-e6206213bdc0 (`pitch_integ`)
- https://logs.px4.io/plot_app?log=2467b8a0-de1a-41b0-8519-a00ddd514bba (`pitch_integ`)
- https://logs.px4.io/plot_app?log=f98e10d3-df37-45c5-a4db-9d891247ce7d (`pitch_integ`, GPS-scrubbed copy used as the test fixture)
- https://logs.px4.io/plot_app?log=df4e4096-d873-412c-b62b-2efe61c62dc2 (`pitch_sp_rad` went non-finite first, not the integrator)
