### PR TITLE
fix(server): hide CI logs from public listing by default

### DIFF
--- a/crates/server/src/db/mod.rs
+++ b/crates/server/src/db/mod.rs
@@ -201,7 +201,7 @@ pub struct LogRecord {
     pub diagnostic_flags: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct ListFilters {
     // Existing filters
     pub sys_name: Option<String>,
@@ -211,6 +211,8 @@ pub struct ListFilters {
     pub limit: Option<i64>,
     /// If true, include private logs in results (default: only public)
     pub include_private: Option<bool>,
+    /// If true, include CI-uploaded logs in public listings (default: hidden, like v1).
+    pub include_ci: Option<bool>,
 
     // Phase 1 search filters
     /// ISO-8601 date string lower bound on created_at

--- a/crates/server/src/db/postgres.rs
+++ b/crates/server/src/db/postgres.rs
@@ -275,6 +275,11 @@ fn build_where_postgres(filters: &ListFilters) -> (String, Vec<String>, usize) {
     if !filters.include_private.unwrap_or(false) {
         conditions.push("is_public = true".to_string());
     }
+    if !filters.include_ci.unwrap_or(false) {
+        conditions.push(format!("(source IS NULL OR source != ${})", param_idx));
+        bind_values.push("CI".to_string());
+        param_idx += 1;
+    }
     if let Some(ref sys_name) = filters.sys_name {
         conditions.push(format!("sys_name = ${}", param_idx));
         bind_values.push(sys_name.clone());

--- a/crates/server/src/db/sqlite.rs
+++ b/crates/server/src/db/sqlite.rs
@@ -304,6 +304,10 @@ fn build_where_sqlite(filters: &ListFilters) -> (String, Vec<String>) {
     if !filters.include_private.unwrap_or(false) {
         conditions.push("is_public = 1".to_string());
     }
+    if !filters.include_ci.unwrap_or(false) {
+        conditions.push("(source IS NULL OR source != ?)".to_string());
+        bind_values.push("CI".to_string());
+    }
     if let Some(ref sys_name) = filters.sys_name {
         conditions.push("sys_name = ?".to_string());
         bind_values.push(sys_name.clone());

--- a/crates/server/tests/listing.rs
+++ b/crates/server/tests/listing.rs
@@ -1,0 +1,72 @@
+use chrono::Utc;
+use flight_review_server::db::{create_db, ListFilters, LogRecord};
+use uuid::Uuid;
+
+fn record(source: Option<&str>) -> LogRecord {
+    LogRecord {
+        id: Uuid::new_v4(),
+        filename: format!("{}.ulg", source.unwrap_or("web")),
+        created_at: Utc::now(),
+        file_size: 42,
+        sys_name: Some("PX4".to_string()),
+        ver_hw: Some("SITL".to_string()),
+        ver_sw_release_str: None,
+        flight_duration_s: Some(12.0),
+        topic_count: 1,
+        lat: None,
+        lon: None,
+        is_public: true,
+        delete_token: Uuid::new_v4().simple().to_string(),
+        description: source.map(|s| format!("{s} upload")),
+        wind_speed: None,
+        rating: None,
+        feedback: None,
+        video_url: None,
+        source: source.map(str::to_string),
+        pilot_name: None,
+        vehicle_name: None,
+        tags: None,
+        location_name: None,
+        mission_type: None,
+        sys_uuid: None,
+        ver_sw: None,
+        vehicle_type: None,
+        localization_sources: None,
+        vibration_status: None,
+        battery_min_voltage: None,
+        gps_max_eph: None,
+        max_speed_m_s: None,
+        total_distance_m: None,
+        error_count: None,
+        warning_count: None,
+        analysis_version: None,
+        diagnostic_flags: None,
+    }
+}
+
+#[tokio::test]
+async fn public_listing_excludes_ci_uploads_by_default() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db_url = format!("sqlite://{}", tmp.path().join("listing.db").display());
+    let db = create_db(&db_url).await.unwrap();
+
+    let web = record(Some("webui"));
+    let ci = record(Some("CI"));
+    db.insert(&web).await.unwrap();
+    db.insert(&ci).await.unwrap();
+
+    let default = db.list(&ListFilters::default()).await.unwrap();
+    assert_eq!(default.total, 1);
+    assert_eq!(default.logs[0].id, web.id);
+
+    let with_ci = db
+        .list(&ListFilters {
+            include_ci: Some(true),
+            ..ListFilters::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(with_ci.total, 2);
+    assert!(with_ci.logs.iter().any(|log| log.id == web.id));
+    assert!(with_ci.logs.iter().any(|log| log.id == ci.id));
+}


### PR DESCRIPTION
## Summary
- Match legacy Flight Review listing behavior by hiding `source=CI` logs from default public `/api/logs` results.
- Add `include_ci=true` as an explicit opt-in for tools/admin views that need CI uploads.
- Cover the listing behavior with a SQLite-backed server DB regression test.

## Why
Legacy Flight Review browse/db-info queries use `Logs.Public = 1 AND NOT Logs.Source = 'CI'`, so CI logs do not pollute the public browse/listing surface. v2 was returning public CI uploads by default, which is a parity gap in the listing API.

## Test plan
- [x] `cargo test -p flight-review-server --test listing --features sqlite`
- [x] `cargo check -p flight-review-server --features sqlite`
- [x] `cargo check -p flight-review-server --no-default-features --features postgres`

Note: the broader server fixture-based tests currently require real Git LFS `.ulg` fixtures; this checkout has pointer files only (`git-lfs` is not installed), so those tests fail before reaching this change with `invalid file: The header does not match the template`.
