### PR TITLE
Search logs by firmware hash and system UUID

### DIFF
--- a/crates/server/src/db/postgres.rs
+++ b/crates/server/src/db/postgres.rs
@@ -290,7 +290,7 @@ fn build_where_postgres(filters: &ListFilters) -> (String, Vec<String>, usize) {
             "(filename ILIKE ${p0} OR sys_name ILIKE ${p1} OR ver_hw ILIKE ${p2} \
              OR description ILIKE ${p3} OR vehicle_name ILIKE ${p4} OR tags ILIKE ${p5} \
              OR location_name ILIKE ${p6} OR ver_sw_release_str ILIKE ${p7} \
-             OR vehicle_type ILIKE ${p8})",
+             OR vehicle_type ILIKE ${p8} OR ver_sw ILIKE ${p9} OR sys_uuid ILIKE ${p10})",
             p0 = param_idx,
             p1 = param_idx + 1,
             p2 = param_idx + 2,
@@ -300,12 +300,14 @@ fn build_where_postgres(filters: &ListFilters) -> (String, Vec<String>, usize) {
             p6 = param_idx + 6,
             p7 = param_idx + 7,
             p8 = param_idx + 8,
+            p9 = param_idx + 9,
+            p10 = param_idx + 10,
         ));
         let pattern = format!("%{}%", search);
-        for _ in 0..9 {
+        for _ in 0..11 {
             bind_values.push(pattern.clone());
         }
-        param_idx += 9;
+        param_idx += 11;
     }
     if let Some(ref date_from) = filters.date_from {
         conditions.push(format!("created_at >= ${}", param_idx));

--- a/crates/server/src/db/sqlite.rs
+++ b/crates/server/src/db/sqlite.rs
@@ -316,11 +316,12 @@ fn build_where_sqlite(filters: &ListFilters) -> (String, Vec<String>) {
         conditions.push(
             "(filename LIKE ? OR sys_name LIKE ? OR ver_hw LIKE ? OR description LIKE ? \
              OR vehicle_name LIKE ? OR tags LIKE ? OR location_name LIKE ? \
-             OR ver_sw_release_str LIKE ? OR vehicle_type LIKE ?)"
+             OR ver_sw_release_str LIKE ? OR vehicle_type LIKE ? OR ver_sw LIKE ? \
+             OR sys_uuid LIKE ?)"
                 .to_string(),
         );
         let pattern = format!("%{}%", search);
-        for _ in 0..9 {
+        for _ in 0..11 {
             bind_values.push(pattern.clone());
         }
     }


### PR DESCRIPTION
## Summary

- Extends the generic log listing search to include the stored PX4 firmware git hash (`ver_sw`)
- Extends the same search predicate to include the vehicle/system UUID (`sys_uuid`)
- Keeps SQLite and Postgres search predicates in sync

## Why

`GET /api/logs?search=...` already searched fields like filename, description, hardware, release string, and vehicle type. However, logs imported or uploaded with only a firmware git hash or vehicle UUID could not be found through the generic browse search.

The server already stores `ver_sw` and `sys_uuid`; this PR adds those existing columns to the generic search predicate.

Closes #35


