### PR TITLE
feat(server): serve frontend assets from Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,6 @@ target/
 .git/
 .claude/
 *.ulg
+frontend/node_modules/
+frontend/build/
+frontend/.svelte-kit/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,17 @@ ARG SERVER_FEATURES=postgres
 RUN cargo build --release -p flight-review-server --features "$SERVER_FEATURES" \
     && cargo build --release -p flight-review --bin ulog-convert
 
+FROM node:22-bookworm-slim AS frontend
+
+WORKDIR /build/frontend
+
+COPY frontend/package*.json ./
+RUN npm ci --include=optional --no-audit --no-fund
+
+COPY frontend/ ./
+ARG PUBLIC_MAPBOX_TOKEN=""
+RUN npm run build
+
 # Runtime image — minimal, no Rust toolchain
 FROM debian:bookworm-slim
 
@@ -20,6 +31,7 @@ RUN apt-get update \
 
 COPY --from=builder /build/target/release/flight-review-server /usr/local/bin/
 COPY --from=builder /build/target/release/ulog-convert /usr/local/bin/
+COPY --from=frontend /build/frontend/build /usr/share/flight-review/frontend
 
 # Default data directory
 RUN mkdir -p /data/files
@@ -27,4 +39,4 @@ RUN mkdir -p /data/files
 EXPOSE 8080
 
 ENTRYPOINT ["flight-review-server"]
-CMD ["serve", "--db", "sqlite:///data/flight-review.db", "--storage", "file:///data/files"]
+CMD ["serve", "--db", "sqlite:///data/flight-review.db", "--storage", "file:///data/files", "--frontend-dir", "/usr/share/flight-review/frontend"]

--- a/README.md
+++ b/README.md
@@ -401,7 +401,8 @@ Postgres for the database, S3 for file storage, and optionally CloudFront for CD
 docker run -p 8080:8080 \
   flight-review serve \
   --db postgres://user:pass@host/flightreview \
-  --storage s3://my-bucket/logs
+  --storage s3://my-bucket/logs \
+  --frontend-dir /usr/share/flight-review/frontend
 
 # Full AWS example with credentials
 docker run -p 8080:8080 \
@@ -411,7 +412,8 @@ docker run -p 8080:8080 \
   flight-review serve \
   --db postgres://user:pass@rds-host.amazonaws.com/flightreview \
   --storage s3://px4-flight-review \
-  --v1-ulg-prefix flight_review/log_files
+  --v1-ulg-prefix flight_review/log_files \
+  --frontend-dir /usr/share/flight-review/frontend
 ```
 
 ## Migrate from v1

--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ npm run dev
 
 The Vite dev server runs on `http://localhost:5173` and proxies all `/api` requests to the backend at `http://localhost:8080`. Open the Vite URL in the browser for development.
 
+For production-like local testing without Vite, build the frontend and pass `--frontend-dir frontend/build` to the server (see [Release Build](#release-build) and [Minimal (single binary)](#minimal-single-binary)).
+
 **Tests:**
 
 ```bash
@@ -304,7 +306,16 @@ Build the frontend for production:
 cd frontend && npm run build
 ```
 
-This produces static files in `frontend/build/` that can be served by the backend or any static file server.
+This produces static files in `frontend/build/`. Serve them from the same process as the API:
+
+```bash
+./target/release/flight-review-server serve \
+  --db sqlite:///data/flight-review.db \
+  --storage file:///data/files \
+  --frontend-dir frontend/build
+```
+
+When `--frontend-dir` is omitted, the server exposes API routes only.
 
 ### Feature Flags
 
@@ -351,6 +362,7 @@ Just run the binary with SQLite and local files -- no external services required
 ./flight-review-server serve \
   --db sqlite:///data/flight-review.db \
   --storage file:///data/files \
+  --frontend-dir frontend/build \
   --port 8080
 
 # Upload a log
@@ -365,15 +377,20 @@ curl http://localhost:8080/api/logs
 
 ### Docker
 
-The Dockerfile currently builds the backend only. The frontend must be built separately (`cd frontend && npm run build`) and served via a reverse proxy or integrated into the container build.
+The Dockerfile is a multi-stage build: Rust compiles the server and CLI, Node builds the SvelteKit frontend, and the runtime image serves both from a single container on port 8080.
 
 ```bash
-# Build
+# Build (frontend is compiled inside the image)
 docker build -t flight-review .
 
-# Run with local storage
-docker run -p 8080:8080 -v /data:/data flight-review
+# Optional: enable Mapbox maps in the viewer
+docker build --build-arg PUBLIC_MAPBOX_TOKEN=pk.your_token -t flight-review .
+
+# Run with persistent data
+docker run --rm -p 8080:8080 -v "$(pwd)/data:/data" flight-review
 ```
+
+The default command serves the UI and API together (`--frontend-dir /usr/share/flight-review/frontend`). Open `http://localhost:8080` in a browser.
 
 ### Production (AWS)
 
@@ -628,7 +645,6 @@ Shared DSP functions available in `dsp.rs`: `median_sample_rate`, `resample_unif
 - **User Accounts** -- optional authentication with email magic links, layered on top of the existing anonymous upload model
 - **PID Analysis API** -- server-side endpoint exposing the existing PID step response analysis for frontend consumption
 - **Dark Mode Polish** -- consistent dark mode across all pages (foundation exists but not fully polished)
-- **Frontend Production Build** -- integrate static frontend build into Docker image and server binary
 
 ## License
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,3 +1,4 @@
+use axum::{http::StatusCode, routing::any};
 use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -129,7 +130,10 @@ async fn run_server(config: ServeConfig) {
     let mut app = flight_review_server::build_router(state);
     if let Some(frontend_dir) = config.frontend_dir {
         let index = frontend_dir.join("index.html");
-        app = app.fallback_service(ServeDir::new(frontend_dir).fallback(ServeFile::new(index)));
+        app = app
+            .route("/api", any(api_not_found))
+            .route("/api/{*path}", any(api_not_found))
+            .fallback_service(ServeDir::new(frontend_dir).fallback(ServeFile::new(index)));
     }
 
     let addr = format!("{}:{}", config.host, config.port);
@@ -141,6 +145,10 @@ async fn run_server(config: ServeConfig) {
     axum::serve(listener, app)
         .await
         .expect("server error");
+}
+
+async fn api_not_found() -> StatusCode {
+    StatusCode::NOT_FOUND
 }
 
 /// Map v1 MavType string to a normalized vehicle type category.

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,6 +1,8 @@
 use clap::{Args, Parser, Subcommand};
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::net::TcpListener;
+use tower_http::services::{ServeDir, ServeFile};
 use tracing_subscriber::EnvFilter;
 
 use flight_review_server::{db, storage::FileStorage, AppState};
@@ -47,6 +49,11 @@ struct ServeConfig {
     /// Can also be set via the MAPBOX_ACCESS_TOKEN environment variable.
     #[arg(long, env = "MAPBOX_ACCESS_TOKEN")]
     mapbox_token: Option<String>,
+
+    /// Directory containing built frontend assets to serve.
+    /// When omitted, the server exposes API routes only.
+    #[arg(long)]
+    frontend_dir: Option<PathBuf>,
 }
 
 #[derive(Args)]
@@ -100,6 +107,9 @@ async fn run_server(config: ServeConfig) {
     if config.mapbox_token.is_some() {
         tracing::info!("mapbox geocoding: enabled");
     }
+    if let Some(ref frontend_dir) = config.frontend_dir {
+        tracing::info!("frontend: {}", frontend_dir.display());
+    }
 
     let db = db::create_db(&config.db)
         .await
@@ -116,7 +126,11 @@ async fn run_server(config: ServeConfig) {
         http_client: reqwest::Client::new(),
     });
 
-    let app = flight_review_server::build_router(state);
+    let mut app = flight_review_server::build_router(state);
+    if let Some(frontend_dir) = config.frontend_dir {
+        let index = frontend_dir.join("index.html");
+        app = app.fallback_service(ServeDir::new(frontend_dir).fallback(ServeFile::new(index)));
+    }
 
     let addr = format!("{}:{}", config.host, config.port);
     let listener = TcpListener::bind(&addr)


### PR DESCRIPTION
Builds the Svelte frontend inside the Docker image and serves the compiled app from `flight-review-server`, closing #44.

The Dockerfile now has a Node build stage that runs `npm ci --include=optional --no-audit --no-fund`, builds the frontend with an optional `PUBLIC_MAPBOX_TOKEN` build arg, and copies `frontend/build` into the runtime image at `/usr/share/flight-review/frontend`. The default container command passes `--frontend-dir /usr/share/flight-review/frontend`, so the image serves the UI and API together on port 8080.

On the server side, `flight-review-server serve` gains an explicit `--frontend-dir <path>` flag. When omitted, the server keeps its existing API-only behavior. When provided, it serves static frontend assets from that directory and falls back non-API routes to `index.html` for SvelteKit SPA routing. Unknown `/api` and `/api/...` requests are handled separately as 404s so API misses do not accidentally return the frontend shell.

The README is updated with production-like local testing, Docker usage, and AWS examples for the bundled frontend path.


Closes #44

Tested:
- `cargo check -p flight-review-server`
- local server run with `--frontend-dir frontend/build`
- verified `/health` and `/api/logs` still work
- verified unknown `/api/...` returns 404
- verified non-API deep links fall back to the Svelte app