### PR TITLE
Add original ULog download endpoint

### DIFF
--- a/crates/server/src/api/logs.rs
+++ b/crates/server/src/api/logs.rs
@@ -130,6 +130,79 @@ pub struct TrackPointCompact {
     pub m: u8, // mode_id, short name to minimize payload
 }
 
+/// GET /api/logs/:id/download -- download the original ULog file.
+pub async fn download_log(
+    State(state): State<Arc<crate::AppState>>,
+    Path(id): Path<Uuid>,
+) -> Result<impl IntoResponse, ApiError> {
+    let record = state.db.get(id).await?.ok_or(ApiError::NotFound)?;
+
+    let mut candidates = vec![record.filename.clone()];
+    let uuid_filename = format!("{id}.ulg");
+    if !candidates.iter().any(|name| name == &uuid_filename) {
+        candidates.push(uuid_filename);
+    }
+
+    for filename in &candidates {
+        if let Ok(data) = state.storage.get_file(id, filename).await {
+            return Ok(ulog_download_response(filename, data));
+        }
+    }
+
+    if state.v1_ulg_prefix.is_some() && lazy_convert(&state, id).await? {
+        for filename in &candidates {
+            if let Ok(data) = state.storage.get_file(id, filename).await {
+                return Ok(ulog_download_response(filename, data));
+            }
+        }
+    }
+
+    let files = state
+        .storage
+        .list_files(id)
+        .await
+        .map_err(|_| ApiError::NotFound)?;
+    if let Some(filename) = files
+        .into_iter()
+        .find(|name| name.to_lowercase().ends_with(".ulg"))
+    {
+        let data = state
+            .storage
+            .get_file(id, &filename)
+            .await
+            .map_err(|_| ApiError::NotFound)?;
+        return Ok(ulog_download_response(&filename, data));
+    }
+
+    Err(ApiError::NotFound)
+}
+
+fn ulog_download_response(filename: &str, data: Bytes) -> axum::response::Response {
+    let safe_filename = filename
+        .chars()
+        .map(|ch| {
+            if ch.is_control() || matches!(ch, '"' | '\\' | '/') {
+                '_'
+            } else {
+                ch
+            }
+        })
+        .collect::<String>();
+    (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "application/octet-stream".to_string()),
+            (
+                header::CONTENT_DISPOSITION,
+                format!("attachment; filename=\"{safe_filename}\""),
+            ),
+            (header::CONTENT_LENGTH, data.len().to_string()),
+        ],
+        data,
+    )
+        .into_response()
+}
+
 /// GET /api/logs/:id/data/:filename -- serve Parquet/metadata files
 /// Supports HTTP Range requests for DuckDB-WASM compatibility.
 /// If the file does not exist in v2 storage but a v1 ULG prefix is configured,

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -43,6 +43,7 @@ pub fn build_router(state: Arc<AppState>) -> Router {
             get(api::logs::get_log).delete(api::logs::delete_log),
         )
         .route("/api/logs/{id}/track", get(api::logs::get_track))
+        .route("/api/logs/{id}/download", get(api::logs::download_log))
         .route(
             "/api/logs/{id}/data/{filename}",
             get(api::logs::get_log_file),

--- a/crates/server/tests/integration.rs
+++ b/crates/server/tests/integration.rs
@@ -230,7 +230,22 @@ async fn test_full_lifecycle() {
     let ulg_size = resp.bytes().await.unwrap().len();
     assert!(ulg_size > 1_000_000, "ULG should be > 1MB");
 
-    // 8. Stats endpoint
+    // 8. Download original .ulg file
+    let resp = client
+        .get(format!("{}/api/logs/{}/download", base_url, log_id))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers()
+            .get("content-disposition")
+            .and_then(|value| value.to_str().ok()),
+        Some("attachment; filename=\"sample.ulg\"")
+    );
+    assert_eq!(resp.bytes().await.unwrap().len(), ulg_size);
+
+    // 9. Stats endpoint
     let resp = client
         .get(format!("{}/api/stats?group_by=ver_hw&period=all", base_url))
         .send()
@@ -242,7 +257,7 @@ async fn test_full_lifecycle() {
     assert!(stats["data"].as_array().unwrap().len() > 0);
     assert_eq!(stats["data"][0]["group"], "AUAV_X21");
 
-    // 9. Search filters
+    // 10. Search filters
     let resp = client
         .get(format!(
             "{}/api/logs?sys_name=PX4&has_gps=false",
@@ -256,7 +271,7 @@ async fn test_full_lifecycle() {
     // sample.ulg may or may not have GPS — just verify the filter doesn't error
     assert!(filtered["total"].as_i64().is_some());
 
-    // 10. Delete with wrong token — should fail
+    // 11. Delete with wrong token — should fail
     let resp = client
         .delete(format!(
             "{}/api/logs/{}?token=wrongtoken",
@@ -267,7 +282,7 @@ async fn test_full_lifecycle() {
         .unwrap();
     assert_eq!(resp.status(), 403, "Wrong token should be forbidden");
 
-    // 11. Delete with correct token
+    // 12. Delete with correct token
     let resp = client
         .delete(format!(
             "{}/api/logs/{}?token={}",
@@ -278,7 +293,7 @@ async fn test_full_lifecycle() {
         .unwrap();
     assert_eq!(resp.status(), 204, "Correct token should succeed");
 
-    // 12. Verify deleted
+    // 13. Verify deleted
     let resp = client
         .get(format!("{}/api/logs/{}", base_url, log_id))
         .send()
@@ -286,7 +301,7 @@ async fn test_full_lifecycle() {
         .unwrap();
     assert_eq!(resp.status(), 404, "Deleted log should return 404");
 
-    // 13. List should be empty
+    // 14. List should be empty
     let resp = client
         .get(format!("{}/api/logs", base_url))
         .send()


### PR DESCRIPTION
## Summary

Adds a backend endpoint for downloading the original uploaded `.ulg` file:

- adds `GET /api/logs/{id}/download`
- reuses the existing DB and storage abstractions
- supports logs stored by original filename and UUID filename
- preserves the existing lazy v1 conversion fallback path
- returns the file as an attachment with `Content-Disposition`

This fixes the existing frontend `.ulg` download button, which already points to `/api/logs/{id}/download` but previously received a 404 because the route was not implemented.

## Testing

- `cargo check -p flight-review-server`
- `cargo test -p flight-review-server --test integration -- --nocapture`