### PR TITLE
Ci/enforce rustfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
       - name: Run tests (all crates)
         run: cargo test --workspace
 

--- a/crates/converter/src/analysis.rs
+++ b/crates/converter/src/analysis.rs
@@ -10,8 +10,8 @@ use px4_ulog::stream_parser::file_reader::{
 };
 use px4_ulog::stream_parser::model::FlattenedFieldType;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct FlightAnalysis {
@@ -152,41 +152,53 @@ impl RunningStats {
         }
         let val = match self.field_type {
             FlattenedFieldType::Float => {
-                if off + 4 > data.len() { return; }
+                if off + 4 > data.len() {
+                    return;
+                }
                 f32::from_le_bytes(data[off..off + 4].try_into().unwrap()) as f64
             }
             FlattenedFieldType::Double => {
-                if off + 8 > data.len() { return; }
+                if off + 8 > data.len() {
+                    return;
+                }
                 f64::from_le_bytes(data[off..off + 8].try_into().unwrap())
             }
             FlattenedFieldType::Int32 => {
-                if off + 4 > data.len() { return; }
+                if off + 4 > data.len() {
+                    return;
+                }
                 i32::from_le_bytes(data[off..off + 4].try_into().unwrap()) as f64
             }
             FlattenedFieldType::UInt32 => {
-                if off + 4 > data.len() { return; }
+                if off + 4 > data.len() {
+                    return;
+                }
                 u32::from_le_bytes(data[off..off + 4].try_into().unwrap()) as f64
             }
             FlattenedFieldType::Int16 => {
-                if off + 2 > data.len() { return; }
+                if off + 2 > data.len() {
+                    return;
+                }
                 i16::from_le_bytes(data[off..off + 2].try_into().unwrap()) as f64
             }
             FlattenedFieldType::UInt16 => {
-                if off + 2 > data.len() { return; }
+                if off + 2 > data.len() {
+                    return;
+                }
                 u16::from_le_bytes(data[off..off + 2].try_into().unwrap()) as f64
             }
-            FlattenedFieldType::Int8 => {
-                data[off] as i8 as f64
-            }
-            FlattenedFieldType::UInt8 => {
-                data[off] as f64
-            }
+            FlattenedFieldType::Int8 => data[off] as i8 as f64,
+            FlattenedFieldType::UInt8 => data[off] as f64,
             FlattenedFieldType::Int64 => {
-                if off + 8 > data.len() { return; }
+                if off + 8 > data.len() {
+                    return;
+                }
                 i64::from_le_bytes(data[off..off + 8].try_into().unwrap()) as f64
             }
             FlattenedFieldType::UInt64 => {
-                if off + 8 > data.len() { return; }
+                if off + 8 > data.len() {
+                    return;
+                }
                 u64::from_le_bytes(data[off..off + 8].try_into().unwrap()) as f64
             }
             FlattenedFieldType::Bool | FlattenedFieldType::Char => return,
@@ -346,402 +358,402 @@ pub fn analyze(path: &str, metadata: &FlightMetadata) -> Result<FlightAnalysis, 
 
     read_file_with_simple_callback(path, &mut |msg| {
         if let Message::Data(data) = msg {
-                let topic = data.flattened_format.message_name.as_str();
-                let ts = data
-                    .flattened_format
-                    .timestamp_field
-                    .as_ref()
-                    .map(|tf| tf.parse_timestamp(data.data));
+            let topic = data.flattened_format.message_name.as_str();
+            let ts = data
+                .flattened_format
+                .timestamp_field
+                .as_ref()
+                .map(|tf| tf.parse_timestamp(data.data));
 
-                // --- Per-field stats tracking (all topics) ---
-                if !topics_initialized.contains_key(topic) {
-                    topics_initialized.insert(topic.to_string(), true);
-                    let mut stats_vec = Vec::new();
-                    let mut numeric_count = 0;
-                    for field in data.flattened_format.field_iter() {
-                        // Skip timestamp field
-                        if field.flattened_field_name == "timestamp" {
-                            continue;
-                        }
-                        if !is_numeric_field_type(&field.field_type) {
-                            continue;
-                        }
-                        if numeric_count >= MAX_FIELDS_PER_TOPIC {
-                            break;
-                        }
-                        stats_vec.push(RunningStats::new(
-                            topic.to_string(),
-                            field.flattened_field_name.clone(),
-                            field.offset,
-                            field.field_type.clone(),
-                        ));
-                        numeric_count += 1;
+            // --- Per-field stats tracking (all topics) ---
+            if !topics_initialized.contains_key(topic) {
+                topics_initialized.insert(topic.to_string(), true);
+                let mut stats_vec = Vec::new();
+                let mut numeric_count = 0;
+                for field in data.flattened_format.field_iter() {
+                    // Skip timestamp field
+                    if field.flattened_field_name == "timestamp" {
+                        continue;
                     }
-                    field_stats_map.insert(topic.to_string(), stats_vec);
+                    if !is_numeric_field_type(&field.field_type) {
+                        continue;
+                    }
+                    if numeric_count >= MAX_FIELDS_PER_TOPIC {
+                        break;
+                    }
+                    stats_vec.push(RunningStats::new(
+                        topic.to_string(),
+                        field.flattened_field_name.clone(),
+                        field.offset,
+                        field.field_type.clone(),
+                    ));
+                    numeric_count += 1;
+                }
+                field_stats_map.insert(topic.to_string(), stats_vec);
+            }
+
+            if let Some(stats_vec) = field_stats_map.get_mut(topic) {
+                for rs in stats_vec.iter_mut() {
+                    rs.update(data.data);
+                }
+            }
+
+            match topic {
+                "vehicle_status" => {
+                    if let Some(ts) = ts {
+                        // nav_state
+                        if let Ok(parser) =
+                            data.flattened_format.get_field_parser::<u8>("nav_state")
+                        {
+                            let nav_state = parser.parse(data.data);
+                            if current_nav_state != Some(nav_state) {
+                                // Close previous segment
+                                if let Some(prev) = current_nav_state {
+                                    analysis.flight_modes.push(FlightModeSegment {
+                                        mode: nav_state_name(prev).to_string(),
+                                        mode_id: prev,
+                                        start_us: mode_start_us,
+                                        end_us: ts,
+                                        duration_s: (ts - mode_start_us) as f64 / 1_000_000.0,
+                                    });
+                                }
+                                current_nav_state = Some(nav_state);
+                                mode_start_us = ts;
+                                mode_changes.push((ts, nav_state));
+                            }
+                        }
+
+                        // VTOL state
+                        let vt = data
+                            .flattened_format
+                            .get_field_parser::<u8>("vehicle_type")
+                            .ok()
+                            .map(|p| p.parse(data.data));
+                        // in_transition_mode can be bool or uint8
+                        let in_trans = data
+                            .flattened_format
+                            .get_field_parser::<u8>("in_transition_mode")
+                            .ok()
+                            .map(|p| p.parse(data.data) != 0);
+
+                        if let (Some(vt_val), Some(it_val)) = (vt, in_trans) {
+                            let changed = current_vehicle_type != Some(vt_val)
+                                || current_in_transition != Some(it_val);
+                            if changed {
+                                // Close previous VTOL segment
+                                if let Some(prev_vt) = current_vehicle_type {
+                                    let prev_it = current_in_transition.unwrap_or(false);
+                                    analysis.vtol_states.push(VtolStateSegment {
+                                        state: vtol_state_name(prev_vt, prev_it).to_string(),
+                                        start_us: vtol_start_us,
+                                        end_us: ts,
+                                    });
+                                }
+                                current_vehicle_type = Some(vt_val);
+                                current_in_transition = Some(it_val);
+                                vtol_start_us = ts;
+                            }
+                        }
+                    }
                 }
 
-                if let Some(stats_vec) = field_stats_map.get_mut(topic) {
-                    for rs in stats_vec.iter_mut() {
-                        rs.update(data.data);
+                "vehicle_local_position" => {
+                    if let (Ok(x_p), Ok(y_p), Ok(z_p), Ok(vx_p), Ok(vy_p), Ok(vz_p)) = (
+                        data.flattened_format.get_field_parser::<f32>("x"),
+                        data.flattened_format.get_field_parser::<f32>("y"),
+                        data.flattened_format.get_field_parser::<f32>("z"),
+                        data.flattened_format.get_field_parser::<f32>("vx"),
+                        data.flattened_format.get_field_parser::<f32>("vy"),
+                        data.flattened_format.get_field_parser::<f32>("vz"),
+                    ) {
+                        let x = x_p.parse(data.data);
+                        let y = y_p.parse(data.data);
+                        let z = z_p.parse(data.data);
+                        let vx = vx_p.parse(data.data);
+                        let vy = vy_p.parse(data.data);
+                        let vz = vz_p.parse(data.data);
+
+                        // Skip NaN values
+                        if x.is_finite() && y.is_finite() && z.is_finite() {
+                            // Distance accumulation
+                            if let Some((px, py, pz)) = prev_pos {
+                                let dx = (x - px) as f64;
+                                let dy = (y - py) as f64;
+                                let dz = (z - pz) as f64;
+                                total_distance += (dx * dx + dy * dy + dz * dz).sqrt();
+                            }
+                            prev_pos = Some((x, y, z));
+
+                            // Altitude tracking (NED: z negative = up)
+                            if z < min_z {
+                                min_z = z;
+                            }
+                            if z > max_z {
+                                max_z = z;
+                            }
+                        }
+
+                        if vx.is_finite() && vy.is_finite() && vz.is_finite() {
+                            let speed_3d = ((vx * vx + vy * vy + vz * vz) as f64).sqrt() as f32;
+                            let speed_h = ((vx * vx + vy * vy) as f64).sqrt() as f32;
+
+                            if speed_3d > max_speed_3d {
+                                max_speed_3d = speed_3d;
+                            }
+                            if speed_h > max_speed_h {
+                                max_speed_h = speed_h;
+                            }
+                            // NED: negative vz = up
+                            if -vz > max_speed_up {
+                                max_speed_up = -vz;
+                            }
+                            if vz > max_speed_down {
+                                max_speed_down = vz;
+                            }
+
+                            speed_sum += speed_3d as f64;
+                            speed_count += 1;
+                        }
                     }
                 }
 
-                match topic {
-                    "vehicle_status" => {
-                        if let Some(ts) = ts {
-                            // nav_state
-                            if let Ok(parser) =
-                                data.flattened_format.get_field_parser::<u8>("nav_state")
-                            {
-                                let nav_state = parser.parse(data.data);
-                                if current_nav_state != Some(nav_state) {
-                                    // Close previous segment
-                                    if let Some(prev) = current_nav_state {
-                                        analysis.flight_modes.push(FlightModeSegment {
-                                            mode: nav_state_name(prev).to_string(),
-                                            mode_id: prev,
-                                            start_us: mode_start_us,
-                                            end_us: ts,
-                                            duration_s: (ts - mode_start_us) as f64 / 1_000_000.0,
-                                        });
-                                    }
-                                    current_nav_state = Some(nav_state);
-                                    mode_start_us = ts;
-                                    mode_changes.push((ts, nav_state));
-                                }
-                            }
+                "vehicle_attitude" => {
+                    // Quaternion fields are flattened as q[0], q[1], q[2], q[3]
+                    if let (Ok(q0_p), Ok(q1_p), Ok(q2_p), Ok(q3_p)) = (
+                        data.flattened_format.get_field_parser::<f32>("q[0]"),
+                        data.flattened_format.get_field_parser::<f32>("q[1]"),
+                        data.flattened_format.get_field_parser::<f32>("q[2]"),
+                        data.flattened_format.get_field_parser::<f32>("q[3]"),
+                    ) {
+                        let q0 = q0_p.parse(data.data);
+                        let q1 = q1_p.parse(data.data);
+                        let q2 = q2_p.parse(data.data);
+                        let q3 = q3_p.parse(data.data);
 
-                            // VTOL state
-                            let vt = data
-                                .flattened_format
-                                .get_field_parser::<u8>("vehicle_type")
-                                .ok()
-                                .map(|p| p.parse(data.data));
-                            // in_transition_mode can be bool or uint8
-                            let in_trans = data
-                                .flattened_format
-                                .get_field_parser::<u8>("in_transition_mode")
-                                .ok()
-                                .map(|p| p.parse(data.data) != 0);
+                        if q0.is_finite() && q1.is_finite() && q2.is_finite() && q3.is_finite() {
+                            // Euler angles from quaternion
+                            let roll =
+                                (2.0 * (q0 * q1 + q2 * q3)).atan2(1.0 - 2.0 * (q1 * q1 + q2 * q2));
+                            let sin_pitch = 2.0 * (q0 * q2 - q3 * q1);
+                            let pitch = if sin_pitch.abs() >= 1.0 {
+                                std::f32::consts::FRAC_PI_2.copysign(sin_pitch)
+                            } else {
+                                sin_pitch.asin()
+                            };
 
-                            if let (Some(vt_val), Some(it_val)) = (vt, in_trans) {
-                                let changed = current_vehicle_type != Some(vt_val)
-                                    || current_in_transition != Some(it_val);
-                                if changed {
-                                    // Close previous VTOL segment
-                                    if let Some(prev_vt) = current_vehicle_type {
-                                        let prev_it = current_in_transition.unwrap_or(false);
-                                        analysis.vtol_states.push(VtolStateSegment {
-                                            state: vtol_state_name(prev_vt, prev_it).to_string(),
-                                            start_us: vtol_start_us,
-                                            end_us: ts,
-                                        });
-                                    }
-                                    current_vehicle_type = Some(vt_val);
-                                    current_in_transition = Some(it_val);
-                                    vtol_start_us = ts;
-                                }
+                            let tilt = (pitch.cos() * roll.cos()).acos();
+                            if tilt.is_finite() && tilt > max_tilt_rad {
+                                max_tilt_rad = tilt;
                             }
                         }
                     }
+                }
 
-                    "vehicle_local_position" => {
-                        if let (Ok(x_p), Ok(y_p), Ok(z_p), Ok(vx_p), Ok(vy_p), Ok(vz_p)) = (
-                            data.flattened_format.get_field_parser::<f32>("x"),
-                            data.flattened_format.get_field_parser::<f32>("y"),
-                            data.flattened_format.get_field_parser::<f32>("z"),
-                            data.flattened_format.get_field_parser::<f32>("vx"),
-                            data.flattened_format.get_field_parser::<f32>("vy"),
-                            data.flattened_format.get_field_parser::<f32>("vz"),
-                        ) {
-                            let x = x_p.parse(data.data);
-                            let y = y_p.parse(data.data);
-                            let z = z_p.parse(data.data);
-                            let vx = vx_p.parse(data.data);
-                            let vy = vy_p.parse(data.data);
-                            let vz = vz_p.parse(data.data);
-
-                            // Skip NaN values
-                            if x.is_finite() && y.is_finite() && z.is_finite() {
-                                // Distance accumulation
-                                if let Some((px, py, pz)) = prev_pos {
-                                    let dx = (x - px) as f64;
-                                    let dy = (y - py) as f64;
-                                    let dz = (z - pz) as f64;
-                                    total_distance += (dx * dx + dy * dy + dz * dz).sqrt();
-                                }
-                                prev_pos = Some((x, y, z));
-
-                                // Altitude tracking (NED: z negative = up)
-                                if z < min_z {
-                                    min_z = z;
-                                }
-                                if z > max_z {
-                                    max_z = z;
-                                }
-                            }
-
-                            if vx.is_finite() && vy.is_finite() && vz.is_finite() {
-                                let speed_3d =
-                                    ((vx * vx + vy * vy + vz * vz) as f64).sqrt() as f32;
-                                let speed_h = ((vx * vx + vy * vy) as f64).sqrt() as f32;
-
-                                if speed_3d > max_speed_3d {
-                                    max_speed_3d = speed_3d;
-                                }
-                                if speed_h > max_speed_h {
-                                    max_speed_h = speed_h;
-                                }
-                                // NED: negative vz = up
-                                if -vz > max_speed_up {
-                                    max_speed_up = -vz;
-                                }
-                                if vz > max_speed_down {
-                                    max_speed_down = vz;
-                                }
-
-                                speed_sum += speed_3d as f64;
-                                speed_count += 1;
+                "vehicle_angular_velocity" => {
+                    // Angular velocity fields: xyz[0], xyz[1], xyz[2]
+                    if let (Ok(x_p), Ok(y_p), Ok(z_p)) = (
+                        data.flattened_format.get_field_parser::<f32>("xyz[0]"),
+                        data.flattened_format.get_field_parser::<f32>("xyz[1]"),
+                        data.flattened_format.get_field_parser::<f32>("xyz[2]"),
+                    ) {
+                        let wx = x_p.parse(data.data);
+                        let wy = y_p.parse(data.data);
+                        let wz = z_p.parse(data.data);
+                        if wx.is_finite() && wy.is_finite() && wz.is_finite() {
+                            let rot_speed = ((wx * wx + wy * wy + wz * wz) as f64).sqrt() as f32;
+                            if rot_speed > max_rotation_speed_rad_s {
+                                max_rotation_speed_rad_s = rot_speed;
                             }
                         }
                     }
+                }
 
-                    "vehicle_attitude" => {
-                        // Quaternion fields are flattened as q[0], q[1], q[2], q[3]
-                        if let (Ok(q0_p), Ok(q1_p), Ok(q2_p), Ok(q3_p)) = (
-                            data.flattened_format.get_field_parser::<f32>("q[0]"),
-                            data.flattened_format.get_field_parser::<f32>("q[1]"),
-                            data.flattened_format.get_field_parser::<f32>("q[2]"),
-                            data.flattened_format.get_field_parser::<f32>("q[3]"),
-                        ) {
-                            let q0 = q0_p.parse(data.data);
-                            let q1 = q1_p.parse(data.data);
-                            let q2 = q2_p.parse(data.data);
-                            let q3 = q3_p.parse(data.data);
+                "battery_status" => {
+                    let current = data
+                        .flattened_format
+                        .get_field_parser::<f32>("current_a")
+                        .ok()
+                        .map(|p| p.parse(data.data));
+                    let voltage = data
+                        .flattened_format
+                        .get_field_parser::<f32>("voltage_v")
+                        .ok()
+                        .map(|p| p.parse(data.data));
+                    let discharged = data
+                        .flattened_format
+                        .get_field_parser::<f32>("discharged_mah")
+                        .ok()
+                        .map(|p| p.parse(data.data));
 
-                            if q0.is_finite() && q1.is_finite() && q2.is_finite() && q3.is_finite()
-                            {
-                                // Euler angles from quaternion
-                                let roll = (2.0 * (q0 * q1 + q2 * q3))
-                                    .atan2(1.0 - 2.0 * (q1 * q1 + q2 * q2));
-                                let sin_pitch = 2.0 * (q0 * q2 - q3 * q1);
-                                let pitch = if sin_pitch.abs() >= 1.0 {
-                                    std::f32::consts::FRAC_PI_2.copysign(sin_pitch)
+                    if let Some(c) = current {
+                        if c.is_finite() && c >= 0.0 {
+                            has_battery_data = true;
+                            current_sum += c as f64;
+                            current_count += 1;
+                            if c > max_current {
+                                max_current = c;
+                            }
+                        }
+                    }
+                    if let Some(v) = voltage {
+                        if v.is_finite() && v > 0.0 {
+                            has_battery_data = true;
+                            if v < min_voltage {
+                                min_voltage = v;
+                            }
+                        }
+                    }
+                    if let Some(d) = discharged {
+                        if d.is_finite() && d >= 0.0 {
+                            has_battery_data = true;
+                            last_discharged = Some(d);
+                        }
+                    }
+                }
+
+                "vehicle_gps_position" => {
+                    if let Some(ts) = ts {
+                        // GPS quality
+                        let sats = data
+                            .flattened_format
+                            .get_field_parser::<u8>("satellites_used")
+                            .ok()
+                            .map(|p| p.parse(data.data));
+                        let fix_type = data
+                            .flattened_format
+                            .get_field_parser::<u8>("fix_type")
+                            .ok()
+                            .map(|p| p.parse(data.data));
+                        let hdop = data
+                            .flattened_format
+                            .get_field_parser::<f32>("hdop")
+                            .ok()
+                            .map(|p| p.parse(data.data));
+                        let eph = data
+                            .flattened_format
+                            .get_field_parser::<f32>("eph")
+                            .ok()
+                            .map(|p| p.parse(data.data));
+                        let epv = data
+                            .flattened_format
+                            .get_field_parser::<f32>("epv")
+                            .ok()
+                            .map(|p| p.parse(data.data));
+
+                        if let Some(s) = sats {
+                            has_gps_quality = true;
+                            let s16 = s as u16;
+                            if s16 < min_sats {
+                                min_sats = s16;
+                            }
+                            if s16 > max_sats {
+                                max_sats = s16;
+                            }
+                        }
+                        if let Some(ft) = fix_type {
+                            has_gps_quality = true;
+                            if !fix_types_seen.contains(&ft) {
+                                fix_types_seen.push(ft);
+                            }
+                        }
+                        if let Some(h) = hdop {
+                            if h.is_finite() && h > max_hdop {
+                                max_hdop = h;
+                            }
+                        }
+                        if let Some(e) = eph {
+                            if e.is_finite() && e > max_eph {
+                                max_eph = e;
+                            }
+                        }
+                        if let Some(e) = epv {
+                            if e.is_finite() && e > max_epv {
+                                max_epv = e;
+                            }
+                        }
+
+                        // GPS track — downsample to ~1 Hz, only 3D fix or better
+                        let ft = fix_type.unwrap_or(0);
+                        if ft > 2 && (ts - last_track_ts) >= 1_000_000 {
+                            // Try new field names (f64 degrees) first, fall back to legacy (i32 raw)
+                            let coords: Option<(f64, f64, f64)> =
+                                if let (Ok(lat_p), Ok(lon_p), Ok(alt_p)) = (
+                                    data.flattened_format
+                                        .get_field_parser::<f64>("latitude_deg"),
+                                    data.flattened_format
+                                        .get_field_parser::<f64>("longitude_deg"),
+                                    data.flattened_format
+                                        .get_field_parser::<f64>("altitude_msl_m"),
+                                ) {
+                                    let lat = lat_p.parse(data.data);
+                                    let lon = lon_p.parse(data.data);
+                                    let alt = alt_p.parse(data.data);
+                                    Some((lat, lon, alt))
+                                } else if let (Ok(lat_p), Ok(lon_p), Ok(alt_p)) = (
+                                    data.flattened_format.get_field_parser::<i32>("lat"),
+                                    data.flattened_format.get_field_parser::<i32>("lon"),
+                                    data.flattened_format.get_field_parser::<i32>("alt"),
+                                ) {
+                                    let lat = lat_p.parse(data.data);
+                                    let lon = lon_p.parse(data.data);
+                                    let alt = alt_p.parse(data.data);
+                                    Some((lat as f64 * 1e-7, lon as f64 * 1e-7, alt as f64 * 1e-3))
                                 } else {
-                                    sin_pitch.asin()
+                                    None
                                 };
 
-                                let tilt = (pitch.cos() * roll.cos()).acos();
-                                if tilt.is_finite() && tilt > max_tilt_rad {
-                                    max_tilt_rad = tilt;
+                            if let Some((lat_deg, lon_deg, alt_m)) = coords {
+                                if lat_deg != 0.0 || lon_deg != 0.0 {
+                                    // Find current mode from mode_changes
+                                    let mode_id = mode_changes
+                                        .iter()
+                                        .rev()
+                                        .find(|(t, _)| *t <= ts)
+                                        .map(|(_, m)| *m)
+                                        .unwrap_or(0);
+
+                                    analysis.gps_track.push(TrackPoint {
+                                        lat_deg,
+                                        lon_deg,
+                                        alt_m,
+                                        timestamp_us: ts,
+                                        mode_id,
+                                    });
+                                    last_track_ts = ts;
                                 }
                             }
                         }
                     }
-
-                    "vehicle_angular_velocity" => {
-                        // Angular velocity fields: xyz[0], xyz[1], xyz[2]
-                        if let (Ok(x_p), Ok(y_p), Ok(z_p)) = (
-                            data.flattened_format.get_field_parser::<f32>("xyz[0]"),
-                            data.flattened_format.get_field_parser::<f32>("xyz[1]"),
-                            data.flattened_format.get_field_parser::<f32>("xyz[2]"),
-                        ) {
-                            let wx = x_p.parse(data.data);
-                            let wy = y_p.parse(data.data);
-                            let wz = z_p.parse(data.data);
-                            if wx.is_finite() && wy.is_finite() && wz.is_finite() {
-                                let rot_speed =
-                                    ((wx * wx + wy * wy + wz * wz) as f64).sqrt() as f32;
-                                if rot_speed > max_rotation_speed_rad_s {
-                                    max_rotation_speed_rad_s = rot_speed;
-                                }
-                            }
-                        }
-                    }
-
-                    "battery_status" => {
-                        let current = data
-                            .flattened_format
-                            .get_field_parser::<f32>("current_a")
-                            .ok()
-                            .map(|p| p.parse(data.data));
-                        let voltage = data
-                            .flattened_format
-                            .get_field_parser::<f32>("voltage_v")
-                            .ok()
-                            .map(|p| p.parse(data.data));
-                        let discharged = data
-                            .flattened_format
-                            .get_field_parser::<f32>("discharged_mah")
-                            .ok()
-                            .map(|p| p.parse(data.data));
-
-                        if let Some(c) = current {
-                            if c.is_finite() && c >= 0.0 {
-                                has_battery_data = true;
-                                current_sum += c as f64;
-                                current_count += 1;
-                                if c > max_current {
-                                    max_current = c;
-                                }
-                            }
-                        }
-                        if let Some(v) = voltage {
-                            if v.is_finite() && v > 0.0 {
-                                has_battery_data = true;
-                                if v < min_voltage {
-                                    min_voltage = v;
-                                }
-                            }
-                        }
-                        if let Some(d) = discharged {
-                            if d.is_finite() && d >= 0.0 {
-                                has_battery_data = true;
-                                last_discharged = Some(d);
-                            }
-                        }
-                    }
-
-                    "vehicle_gps_position" => {
-                        if let Some(ts) = ts {
-                            // GPS quality
-                            let sats = data
-                                .flattened_format
-                                .get_field_parser::<u8>("satellites_used")
-                                .ok()
-                                .map(|p| p.parse(data.data));
-                            let fix_type = data
-                                .flattened_format
-                                .get_field_parser::<u8>("fix_type")
-                                .ok()
-                                .map(|p| p.parse(data.data));
-                            let hdop = data
-                                .flattened_format
-                                .get_field_parser::<f32>("hdop")
-                                .ok()
-                                .map(|p| p.parse(data.data));
-                            let eph = data
-                                .flattened_format
-                                .get_field_parser::<f32>("eph")
-                                .ok()
-                                .map(|p| p.parse(data.data));
-                            let epv = data
-                                .flattened_format
-                                .get_field_parser::<f32>("epv")
-                                .ok()
-                                .map(|p| p.parse(data.data));
-
-                            if let Some(s) = sats {
-                                has_gps_quality = true;
-                                let s16 = s as u16;
-                                if s16 < min_sats {
-                                    min_sats = s16;
-                                }
-                                if s16 > max_sats {
-                                    max_sats = s16;
-                                }
-                            }
-                            if let Some(ft) = fix_type {
-                                has_gps_quality = true;
-                                if !fix_types_seen.contains(&ft) {
-                                    fix_types_seen.push(ft);
-                                }
-                            }
-                            if let Some(h) = hdop {
-                                if h.is_finite() && h > max_hdop {
-                                    max_hdop = h;
-                                }
-                            }
-                            if let Some(e) = eph {
-                                if e.is_finite() && e > max_eph {
-                                    max_eph = e;
-                                }
-                            }
-                            if let Some(e) = epv {
-                                if e.is_finite() && e > max_epv {
-                                    max_epv = e;
-                                }
-                            }
-
-                            // GPS track — downsample to ~1 Hz, only 3D fix or better
-                            let ft = fix_type.unwrap_or(0);
-                            if ft > 2 && (ts - last_track_ts) >= 1_000_000 {
-                                // Try new field names (f64 degrees) first, fall back to legacy (i32 raw)
-                                let coords: Option<(f64, f64, f64)> =
-                                    if let (Ok(lat_p), Ok(lon_p), Ok(alt_p)) = (
-                                        data.flattened_format.get_field_parser::<f64>("latitude_deg"),
-                                        data.flattened_format.get_field_parser::<f64>("longitude_deg"),
-                                        data.flattened_format.get_field_parser::<f64>("altitude_msl_m"),
-                                    ) {
-                                        let lat = lat_p.parse(data.data);
-                                        let lon = lon_p.parse(data.data);
-                                        let alt = alt_p.parse(data.data);
-                                        Some((lat, lon, alt))
-                                    } else if let (Ok(lat_p), Ok(lon_p), Ok(alt_p)) = (
-                                        data.flattened_format.get_field_parser::<i32>("lat"),
-                                        data.flattened_format.get_field_parser::<i32>("lon"),
-                                        data.flattened_format.get_field_parser::<i32>("alt"),
-                                    ) {
-                                        let lat = lat_p.parse(data.data);
-                                        let lon = lon_p.parse(data.data);
-                                        let alt = alt_p.parse(data.data);
-                                        Some((lat as f64 * 1e-7, lon as f64 * 1e-7, alt as f64 * 1e-3))
-                                    } else {
-                                        None
-                                    };
-
-                                if let Some((lat_deg, lon_deg, alt_m)) = coords {
-                                    if lat_deg != 0.0 || lon_deg != 0.0 {
-                                        // Find current mode from mode_changes
-                                        let mode_id = mode_changes
-                                            .iter()
-                                            .rev()
-                                            .find(|(t, _)| *t <= ts)
-                                            .map(|(_, m)| *m)
-                                            .unwrap_or(0);
-
-                                        analysis.gps_track.push(TrackPoint {
-                                            lat_deg,
-                                            lon_deg,
-                                            alt_m,
-                                            timestamp_us: ts,
-                                            mode_id,
-                                        });
-                                        last_track_ts = ts;
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    "vehicle_imu_status" => {
-                        if let Ok(vibe_p) = data
-                            .flattened_format
-                            .get_field_parser::<f32>("accel_vibration_metric")
-                        {
-                            let v = vibe_p.parse(data.data);
-                            if v.is_finite() && v >= 0.0 {
-                                vibe_sum += v as f64;
-                                vibe_count += 1;
-                                if v > vibe_max {
-                                    vibe_max = v;
-                                }
-                            }
-                        }
-                    }
-
-                    _ => {}
                 }
 
-                // Dispatch to diagnostic analyzers
-                if diagnostic_topics.contains(topic) {
-                    for analyzer in analyzers.iter_mut() {
-                        if analyzer.required_topics().contains(&topic) {
-                            analyzer.on_message(data);
+                "vehicle_imu_status" => {
+                    if let Ok(vibe_p) = data
+                        .flattened_format
+                        .get_field_parser::<f32>("accel_vibration_metric")
+                    {
+                        let v = vibe_p.parse(data.data);
+                        if v.is_finite() && v >= 0.0 {
+                            vibe_sum += v as f64;
+                            vibe_count += 1;
+                            if v > vibe_max {
+                                vibe_max = v;
+                            }
                         }
+                    }
+                }
+
+                _ => {}
+            }
+
+            // Dispatch to diagnostic analyzers
+            if diagnostic_topics.contains(topic) {
+                for analyzer in analyzers.iter_mut() {
+                    if analyzer.required_topics().contains(&topic) {
+                        analyzer.on_message(data);
                     }
                 }
             }
+        }
         SimpleCallbackResult::KeepReading
     })?;
 
@@ -878,10 +890,7 @@ pub fn analyze(path: &str, metadata: &FlightMetadata) -> Result<FlightAnalysis, 
         .sort_by(|a, b| a.topic.cmp(&b.topic).then_with(|| a.field.cmp(&b.field)));
 
     // --- Finalize diagnostics ---
-    analysis.diagnostics = analyzers
-        .into_iter()
-        .flat_map(|a| a.finish())
-        .collect();
+    analysis.diagnostics = analyzers.into_iter().flat_map(|a| a.finish()).collect();
 
     Ok(analysis)
 }
@@ -898,19 +907,11 @@ fn compute_non_default_params(metadata: &FlightMetadata, analysis: &mut FlightAn
 
         if let Some(default) = metadata.default_parameters.get(name) {
             let (val_f64, def_f64) = match (value, default) {
-                (ParamValue::Float(v), ParamValue::Float(d)) => {
-                    (*v as f64, *d as f64)
-                }
-                (ParamValue::Int32(v), ParamValue::Int32(d)) => {
-                    (*v as f64, *d as f64)
-                }
+                (ParamValue::Float(v), ParamValue::Float(d)) => (*v as f64, *d as f64),
+                (ParamValue::Int32(v), ParamValue::Int32(d)) => (*v as f64, *d as f64),
                 // Mixed types — compare as f64
-                (ParamValue::Float(v), ParamValue::Int32(d)) => {
-                    (*v as f64, *d as f64)
-                }
-                (ParamValue::Int32(v), ParamValue::Float(d)) => {
-                    (*v as f64, *d as f64)
-                }
+                (ParamValue::Float(v), ParamValue::Int32(d)) => (*v as f64, *d as f64),
+                (ParamValue::Int32(v), ParamValue::Float(d)) => (*v as f64, *d as f64),
             };
 
             if (val_f64 - def_f64).abs() > f64::EPSILON {
@@ -937,8 +938,10 @@ mod tests {
     fn px4_ulog_fixture(name: &str) -> String {
         let manifest = env!("CARGO_MANIFEST_DIR");
         std::path::Path::new(manifest)
-            .parent().unwrap()  // crates/
-            .parent().unwrap()  // workspace root
+            .parent()
+            .unwrap() // crates/
+            .parent()
+            .unwrap() // workspace root
             .join("crates/converter/tests/fixtures")
             .join(name)
             .to_string_lossy()
@@ -998,9 +1001,21 @@ mod tests {
         if !analysis.gps_track.is_empty() {
             // Verify track points have valid coordinates
             for pt in &analysis.gps_track {
-                assert!(pt.lat_deg.abs() <= 90.0, "latitude out of range: {}", pt.lat_deg);
-                assert!(pt.lon_deg.abs() <= 180.0, "longitude out of range: {}", pt.lon_deg);
-                assert!(pt.alt_m.abs() < 100_000.0, "altitude out of range: {}", pt.alt_m);
+                assert!(
+                    pt.lat_deg.abs() <= 90.0,
+                    "latitude out of range: {}",
+                    pt.lat_deg
+                );
+                assert!(
+                    pt.lon_deg.abs() <= 180.0,
+                    "longitude out of range: {}",
+                    pt.lon_deg
+                );
+                assert!(
+                    pt.alt_m.abs() < 100_000.0,
+                    "altitude out of range: {}",
+                    pt.alt_m
+                );
                 assert!(pt.timestamp_us > 0, "timestamp should be positive");
             }
 
@@ -1027,16 +1042,33 @@ mod tests {
         );
 
         // Check we have stats from multiple topics
-        let topics: std::collections::HashSet<&str> =
-            analysis.field_stats.iter().map(|fs| fs.field.as_str()).collect();
+        let topics: std::collections::HashSet<&str> = analysis
+            .field_stats
+            .iter()
+            .map(|fs| fs.field.as_str())
+            .collect();
         assert!(topics.len() > 1, "should have stats for multiple fields");
 
         // All stats should have valid values
         for fs in &analysis.field_stats {
-            assert!(fs.count > 0, "count should be > 0 for {}.{}", fs.topic, fs.field);
-            assert!(fs.min <= fs.max, "min should be <= max for {}.{}", fs.topic, fs.field);
-            assert!(fs.mean >= fs.min && fs.mean <= fs.max,
-                "mean should be between min and max for {}.{}", fs.topic, fs.field);
+            assert!(
+                fs.count > 0,
+                "count should be > 0 for {}.{}",
+                fs.topic,
+                fs.field
+            );
+            assert!(
+                fs.min <= fs.max,
+                "min should be <= max for {}.{}",
+                fs.topic,
+                fs.field
+            );
+            assert!(
+                fs.mean >= fs.min && fs.mean <= fs.max,
+                "mean should be between min and max for {}.{}",
+                fs.topic,
+                fs.field
+            );
         }
     }
 
@@ -1057,8 +1089,11 @@ mod tests {
         );
 
         // Check that known topics are represented
-        let topic_names: std::collections::HashSet<&str> =
-            analysis.field_stats.iter().map(|fs| fs.topic.as_str()).collect();
+        let topic_names: std::collections::HashSet<&str> = analysis
+            .field_stats
+            .iter()
+            .map(|fs| fs.topic.as_str())
+            .collect();
         assert!(
             topic_names.contains("vehicle_attitude"),
             "should have vehicle_attitude stats"

--- a/crates/converter/src/bin/ulog_convert.rs
+++ b/crates/converter/src/bin/ulog_convert.rs
@@ -22,7 +22,11 @@ enum BatchFormat {
 }
 
 #[derive(Parser)]
-#[command(name = "ulog-convert", version, about = "Convert and analyze PX4 ULog files")]
+#[command(
+    name = "ulog-convert",
+    version,
+    about = "Convert and analyze PX4 ULog files"
+)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
@@ -465,10 +469,7 @@ fn run_batch(dir: &str, opts: &BatchOpts, jobs: Option<usize>, format: &BatchFor
             }
 
             // Filter out empty results if diagnostics-only
-            if opts.diagnostics_only
-                && result.diagnostics.is_empty()
-                && result.error.is_none()
-            {
+            if opts.diagnostics_only && result.diagnostics.is_empty() && result.error.is_none() {
                 return None;
             }
 
@@ -706,13 +707,14 @@ fn print_table(results: &[BatchResult], opts: &BatchOpts) {
                         }
                     })
                     .collect();
-                let worst = if r.diagnostics.iter().any(|d| {
-                    matches!(d.severity, flight_review::diagnostics::Severity::Critical)
-                }) {
-                    "!"
-                } else {
-                    " "
-                };
+                let worst =
+                    if r.diagnostics.iter().any(|d| {
+                        matches!(d.severity, flight_review::diagnostics::Severity::Critical)
+                    }) {
+                        "!"
+                    } else {
+                        " "
+                    };
                 line.push_str(&format!(" {worst} {}", diag_str.join(", ")));
             }
         }

--- a/crates/converter/src/converter.rs
+++ b/crates/converter/src/converter.rs
@@ -263,8 +263,10 @@ mod tests {
     fn px4_ulog_fixture(name: &str) -> String {
         let manifest = env!("CARGO_MANIFEST_DIR");
         std::path::Path::new(manifest)
-            .parent().unwrap()  // crates/
-            .parent().unwrap()  // workspace root
+            .parent()
+            .unwrap() // crates/
+            .parent()
+            .unwrap() // workspace root
             .join("crates/converter/tests/fixtures")
             .join(name)
             .to_string_lossy()
@@ -276,7 +278,10 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let result = convert_ulog(&px4_ulog_fixture("sample.ulg"), tmp.path()).unwrap();
 
-        assert!(!result.parquet_files.is_empty(), "Should produce Parquet files");
+        assert!(
+            !result.parquet_files.is_empty(),
+            "Should produce Parquet files"
+        );
 
         // Should have one file per topic
         let has_attitude = result
@@ -340,8 +345,7 @@ mod tests {
             return;
         }
         let tmp = tempfile::tempdir().unwrap();
-        let result =
-            convert_ulog(&path, tmp.path()).unwrap();
+        let result = convert_ulog(&path, tmp.path()).unwrap();
 
         assert!(
             result.parquet_files.len() > 10,

--- a/crates/converter/src/diagnostics/battery_brownout.rs
+++ b/crates/converter/src/diagnostics/battery_brownout.rs
@@ -5,7 +5,7 @@
 //! critical threshold per cell.
 
 use super::{
-    parse_field, AnomalyKind, Analyzer, Diagnostic, Evidence, FieldUnit, OutputDescriptor,
+    parse_field, Analyzer, AnomalyKind, Diagnostic, Evidence, FieldUnit, OutputDescriptor,
     PlotAnchor, Severity,
 };
 use px4_ulog::stream_parser::model::DataMessage;

--- a/crates/converter/src/diagnostics/ekf_failure.rs
+++ b/crates/converter/src/diagnostics/ekf_failure.rs
@@ -6,7 +6,7 @@
 //! unreliable.
 
 use super::{
-    parse_field, AnomalyKind, Analyzer, Diagnostic, Evidence, FieldUnit, OutputDescriptor,
+    parse_field, Analyzer, AnomalyKind, Diagnostic, Evidence, FieldUnit, OutputDescriptor,
     PlotAnchor, Severity,
 };
 use px4_ulog::stream_parser::model::DataMessage;
@@ -69,7 +69,9 @@ impl InnovationTracker {
                         start as f64 / 1_000_000.0,
                     ),
                     severity: Severity::Critical,
-                    kind: AnomalyKind::Region { end_timestamp_us: ts },
+                    kind: AnomalyKind::Region {
+                        end_timestamp_us: ts,
+                    },
                     timestamp_us: start,
                     anchor: PlotAnchor::new("estimator_status", self.field_name),
                     descriptor: descriptor.clone(),
@@ -90,7 +92,9 @@ impl InnovationTracker {
                         start as f64 / 1_000_000.0,
                     ),
                     severity: Severity::Warning,
-                    kind: AnomalyKind::Region { end_timestamp_us: ts },
+                    kind: AnomalyKind::Region {
+                        end_timestamp_us: ts,
+                    },
                     timestamp_us: start,
                     anchor: PlotAnchor::new("estimator_status", self.field_name),
                     descriptor: descriptor.clone(),
@@ -266,7 +270,10 @@ mod tests {
         analyzer.on_message(&dm);
 
         let diags = Box::new(analyzer).finish();
-        assert!(diags.is_empty(), "Should not fire if ratio drops before warning duration");
+        assert!(
+            diags.is_empty(),
+            "Should not fire if ratio drops before warning duration"
+        );
     }
 
     #[test]
@@ -292,10 +299,7 @@ mod tests {
     #[test]
     fn detects_real_ekf_failure() {
         let diags = analyze_fixture_for("ekf_failure.ulg", "ekf_failure");
-        assert!(
-            !diags.is_empty(),
-            "Should detect EKF failures in real log"
-        );
+        assert!(!diags.is_empty(), "Should detect EKF failures in real log");
         // Should detect at least one escalation to critical
         assert!(
             diags.iter().any(|d| d.severity == Severity::Critical),

--- a/crates/converter/src/diagnostics/ekf_selector_whipsaw.rs
+++ b/crates/converter/src/diagnostics/ekf_selector_whipsaw.rs
@@ -14,7 +14,7 @@
 //!   selector switches to (indicates switching to a degraded instance)
 
 use super::{
-    parse_field, AnomalyKind, Analyzer, Diagnostic, Evidence, FieldUnit, OutputDescriptor,
+    parse_field, Analyzer, AnomalyKind, Diagnostic, Evidence, FieldUnit, OutputDescriptor,
     PlotAnchor, Severity,
 };
 use px4_ulog::stream_parser::model::DataMessage;
@@ -185,9 +185,7 @@ impl Analyzer for EkfSelectorWhipsawAnalyzer {
             // current window. `trim_window` above already aged out older ones.
             let switched_to_degraded = !self.degraded_switch_times.is_empty();
 
-            let severity = if switches_in_window >= CRITICAL_SWITCH_COUNT
-                || switched_to_degraded
-            {
+            let severity = if switches_in_window >= CRITICAL_SWITCH_COUNT || switched_to_degraded {
                 Severity::Critical
             } else {
                 Severity::Warning
@@ -221,12 +219,11 @@ impl Analyzer for EkfSelectorWhipsawAnalyzer {
                 id: "ekf_selector_whipsaw".to_string(),
                 summary,
                 severity,
-                kind: AnomalyKind::Region { end_timestamp_us: ts },
+                kind: AnomalyKind::Region {
+                    end_timestamp_us: ts,
+                },
                 timestamp_us: window_start,
-                anchor: PlotAnchor::new(
-                    "estimator_selector_status",
-                    "instance_changed_count",
-                ),
+                anchor: PlotAnchor::new("estimator_selector_status", "instance_changed_count"),
                 descriptor: self.output_descriptor(),
                 evidence: Evidence::EkfSelectorWhipsaw {
                     switch_count: switches_in_window,
@@ -288,12 +285,7 @@ mod tests {
         for i in 0..5 {
             let ts = (i as u64 + 1) * 1_000_000;
             let primary = if i % 2 == 0 { 0 } else { 1 };
-            let (fmt, data) = selector_msg(
-                ts,
-                primary,
-                i as u32,
-                &[(0, 0.5), (1, 0.5)],
-            );
+            let (fmt, data) = selector_msg(ts, primary, i as u32, &[(0, 0.5), (1, 0.5)]);
             let dm = make_data_message(&fmt, &data);
             analyzer.on_message(&dm);
         }
@@ -311,12 +303,7 @@ mod tests {
         for i in 0..5 {
             let ts = (i as u64 + 1) * 1_000_000;
             let primary = if i % 2 == 0 { 0 } else { 1 };
-            let (fmt, data) = selector_msg(
-                ts,
-                primary,
-                i as u32,
-                &[(0, 2.0), (1, 0.3)],
-            );
+            let (fmt, data) = selector_msg(ts, primary, i as u32, &[(0, 2.0), (1, 0.3)]);
             let dm = make_data_message(&fmt, &data);
             analyzer.on_message(&dm);
         }
@@ -364,7 +351,10 @@ mod tests {
         assert!(
             matches!(
                 &diags[0].evidence,
-                Evidence::EkfSelectorWhipsaw { switched_to_degraded: false, .. }
+                Evidence::EkfSelectorWhipsaw {
+                    switched_to_degraded: false,
+                    ..
+                }
             ),
             "switched_to_degraded must be false once the degraded switch ages out"
         );
@@ -433,10 +423,7 @@ mod tests {
 
     #[test]
     fn detects_real_ekf_selector_whipsaw() {
-        let diags = analyze_fixture_for(
-            "ekf_selector_whipsaw.ulg",
-            "ekf_selector_whipsaw",
-        );
+        let diags = analyze_fixture_for("ekf_selector_whipsaw.ulg", "ekf_selector_whipsaw");
         assert!(
             !diags.is_empty(),
             "Should detect whipsaw in real PX4 #27013 log"
@@ -463,10 +450,7 @@ mod tests {
         // Real multi-EKF flight from PX4 PR #23337 (post-fix, ARK_PI6X). The
         // selector is healthy here, so the analyzer must stay silent even
         // though multiple EKF instances are active.
-        let diags = analyze_fixture_for(
-            "ekf_selector_no_whipsaw.ulg",
-            "ekf_selector_whipsaw",
-        );
+        let diags = analyze_fixture_for("ekf_selector_no_whipsaw.ulg", "ekf_selector_whipsaw");
         assert!(
             diags.is_empty(),
             "Clean multi-EKF #23337 log should produce no whipsaw detections, got {}",

--- a/crates/converter/src/diagnostics/gps_interference.rs
+++ b/crates/converter/src/diagnostics/gps_interference.rs
@@ -6,7 +6,7 @@
 //! - Satellite count drops significantly below baseline
 
 use super::{
-    parse_field, AnomalyKind, Analyzer, Diagnostic, Evidence, FieldUnit, OutputDescriptor,
+    parse_field, Analyzer, AnomalyKind, Diagnostic, Evidence, FieldUnit, OutputDescriptor,
     PlotAnchor, Severity,
 };
 use px4_ulog::stream_parser::model::DataMessage;
@@ -124,25 +124,28 @@ impl Analyzer for GpsInterferenceAnalyzer {
         let current_sats = sats.unwrap_or(0);
 
         // EPH spike detection
-        let eph_spike = baseline_eph < 2.0 && current_eph > EPH_SPIKE_THRESHOLD && current_eph.is_finite();
+        let eph_spike =
+            baseline_eph < 2.0 && current_eph > EPH_SPIKE_THRESHOLD && current_eph.is_finite();
         // EPV spike detection
         let epv_spike = current_epv > EPV_THRESHOLD && current_epv.is_finite();
         // Satellite drop detection
-        let sats_drop = baseline_sats > 0.0
-            && (current_sats as f64) < baseline_sats * (1.0 - SATS_DROP_RATIO);
+        let sats_drop =
+            baseline_sats > 0.0 && (current_sats as f64) < baseline_sats * (1.0 - SATS_DROP_RATIO);
 
         if eph_spike || epv_spike || sats_drop {
-            let severity = if current_eph > EPH_CRITICAL_THRESHOLD
-                || current_sats < SATS_CRITICAL_MIN
-            {
-                Severity::Critical
-            } else {
-                Severity::Warning
-            };
+            let severity =
+                if current_eph > EPH_CRITICAL_THRESHOLD || current_sats < SATS_CRITICAL_MIN {
+                    Severity::Critical
+                } else {
+                    Severity::Warning
+                };
 
             let mut reasons = Vec::new();
             if eph_spike {
-                reasons.push(format!("EPH {:.1}m (baseline {:.1}m)", current_eph, baseline_eph));
+                reasons.push(format!(
+                    "EPH {:.1}m (baseline {:.1}m)",
+                    current_eph, baseline_eph
+                ));
             }
             if epv_spike {
                 reasons.push(format!("EPV {:.1}m", current_epv));

--- a/crates/converter/src/diagnostics/motor_failure.rs
+++ b/crates/converter/src/diagnostics/motor_failure.rs
@@ -9,7 +9,7 @@
 use std::collections::{HashSet, VecDeque};
 
 use super::{
-    parse_field, AnomalyKind, Analyzer, Diagnostic, Evidence, FieldUnit, MotorFailureMode,
+    parse_field, Analyzer, AnomalyKind, Diagnostic, Evidence, FieldUnit, MotorFailureMode,
     OutputDescriptor, PlotAnchor, Severity,
 };
 use crate::analysis::nav_state_name;
@@ -110,7 +110,9 @@ impl Analyzer for MotorFailureAnalyzer {
                 if self.motor_count.is_none() {
                     let count = Self::detect_motor_count(data);
                     self.motor_count = Some(count);
-                    self.motor_windows = (0..count).map(|_| VecDeque::with_capacity(WINDOW_SIZE)).collect();
+                    self.motor_windows = (0..count)
+                        .map(|_| VecDeque::with_capacity(WINDOW_SIZE))
+                        .collect();
                     self.motor_was_active = vec![false; count];
                 }
 
@@ -139,7 +141,12 @@ impl Analyzer for MotorFailureAnalyzer {
 
                     // Check: PWM drop to zero — only if motor was previously active
                     let was_active = self.motor_was_active.get(i).copied().unwrap_or(false);
-                    if pwm == 0.0 && was_active && !self.fired.contains(&(motor_idx, MotorFailureMode::DropToZero)) {
+                    if pwm == 0.0
+                        && was_active
+                        && !self
+                            .fired
+                            .contains(&(motor_idx, MotorFailureMode::DropToZero))
+                    {
                         self.fired.insert((motor_idx, MotorFailureMode::DropToZero));
                         self.detections.push(Diagnostic {
                             id: "motor_failure".to_string(),
@@ -167,9 +174,12 @@ impl Analyzer for MotorFailureAnalyzer {
                     if let Some(window) = self.motor_windows.get(i) {
                         if window.len() == WINDOW_SIZE
                             && window.iter().all(|(_, p)| *p >= PWM_MAX_THRESHOLD)
-                            && !self.fired.contains(&(motor_idx, MotorFailureMode::LockedAtMax))
+                            && !self
+                                .fired
+                                .contains(&(motor_idx, MotorFailureMode::LockedAtMax))
                         {
-                            self.fired.insert((motor_idx, MotorFailureMode::LockedAtMax));
+                            self.fired
+                                .insert((motor_idx, MotorFailureMode::LockedAtMax));
                             let first_ts = window.front().map(|(t, _)| *t).unwrap_or(ts);
                             self.detections.push(Diagnostic {
                                 id: "motor_failure".to_string(),
@@ -180,9 +190,14 @@ impl Analyzer for MotorFailureAnalyzer {
                                     ts as f64 / 1_000_000.0,
                                 ),
                                 severity: Severity::Warning,
-                                kind: AnomalyKind::Region { end_timestamp_us: ts },
+                                kind: AnomalyKind::Region {
+                                    end_timestamp_us: ts,
+                                },
                                 timestamp_us: first_ts,
-                                anchor: PlotAnchor::new("actuator_outputs", &format!("output[{i}]")),
+                                anchor: PlotAnchor::new(
+                                    "actuator_outputs",
+                                    &format!("output[{i}]"),
+                                ),
                                 descriptor: self.output_descriptor(),
                                 evidence: Evidence::MotorFailure {
                                     motor_index: motor_idx,
@@ -261,9 +276,7 @@ mod tests {
         assert_eq!(diags[0].anchor.field, "output[1]");
         match &diags[0].evidence {
             Evidence::MotorFailure {
-                motor_index,
-                mode,
-                ..
+                motor_index, mode, ..
             } => {
                 assert_eq!(*motor_index, 1);
                 assert_eq!(*mode, MotorFailureMode::DropToZero);
@@ -303,7 +316,11 @@ mod tests {
         }
 
         let diags = Box::new(analyzer).finish();
-        assert!(diags.is_empty(), "Unused channels should not trigger motor_failure, got: {:?}", diags);
+        assert!(
+            diags.is_empty(),
+            "Unused channels should not trigger motor_failure, got: {:?}",
+            diags
+        );
     }
 
     #[test]
@@ -385,7 +402,11 @@ mod tests {
         }
 
         let diags = Box::new(analyzer).finish();
-        assert_eq!(diags.len(), 1, "Should only fire once per motor per failure mode");
+        assert_eq!(
+            diags.len(),
+            1,
+            "Should only fire once per motor per failure mode"
+        );
     }
 
     #[test]

--- a/crates/converter/src/diagnostics/rc_loss.rs
+++ b/crates/converter/src/diagnostics/rc_loss.rs
@@ -8,7 +8,7 @@
 //! Add a fixture when one becomes available.
 
 use super::{
-    parse_field, AnomalyKind, Analyzer, Diagnostic, Evidence, FieldUnit, OutputDescriptor,
+    parse_field, Analyzer, AnomalyKind, Diagnostic, Evidence, FieldUnit, OutputDescriptor,
     PlotAnchor, Severity,
 };
 use px4_ulog::stream_parser::model::DataMessage;
@@ -64,7 +64,9 @@ impl RcLossAnalyzer {
                 start_us as f64 / 1_000_000.0,
             ),
             severity,
-            kind: AnomalyKind::Region { end_timestamp_us: end_us },
+            kind: AnomalyKind::Region {
+                end_timestamp_us: end_us,
+            },
             timestamp_us: start_us,
             anchor: PlotAnchor::new("input_rc", "rc_lost"),
             descriptor: self.output_descriptor(),
@@ -315,9 +317,7 @@ mod tests {
     fn handles_missing_fields() {
         let mut analyzer = RcLossAnalyzer::new();
 
-        let (fmt, data) = MessageBuilder::new("input_rc")
-            .timestamp(1_000_000)
-            .build();
+        let (fmt, data) = MessageBuilder::new("input_rc").timestamp(1_000_000).build();
         let dm = make_data_message(&fmt, &data);
         analyzer.on_message(&dm); // must not panic
 

--- a/crates/converter/src/diagnostics/tecs_nonfinite_pitch.rs
+++ b/crates/converter/src/diagnostics/tecs_nonfinite_pitch.rs
@@ -10,7 +10,7 @@
 //! per sample is cheap and fits inside the diagnostics budget.
 
 use super::{
-    parse_field, AnomalyKind, Analyzer, Diagnostic, Evidence, FieldUnit, OutputDescriptor,
+    parse_field, Analyzer, AnomalyKind, Diagnostic, Evidence, FieldUnit, OutputDescriptor,
     PlotAnchor, Severity, TecsNonfinitePitchField,
 };
 use px4_ulog::stream_parser::model::DataMessage;
@@ -136,7 +136,12 @@ mod tests {
     use super::*;
     use crate::diagnostics::testing::*;
 
-    fn tecs_msg(ts: u64, pitch_integ: f32, pitch_sp_rad: f32, throttle_integ: f32) -> (px4_ulog::stream_parser::model::FlattenedFormat, Vec<u8>) {
+    fn tecs_msg(
+        ts: u64,
+        pitch_integ: f32,
+        pitch_sp_rad: f32,
+        throttle_integ: f32,
+    ) -> (px4_ulog::stream_parser::model::FlattenedFormat, Vec<u8>) {
         MessageBuilder::new("tecs_status")
             .timestamp(ts)
             .field_f32("pitch_integ", pitch_integ)
@@ -218,7 +223,10 @@ mod tests {
         analyzer.on_message(&make_data_message(&fmt, &data));
         let diags = Box::new(analyzer).finish();
         match &diags[0].evidence {
-            Evidence::TecsNonfinitePitch { throttle_integ_nonfinite, .. } => {
+            Evidence::TecsNonfinitePitch {
+                throttle_integ_nonfinite,
+                ..
+            } => {
                 assert!(*throttle_integ_nonfinite)
             }
             _ => panic!("expected TecsNonfinitePitch"),

--- a/crates/converter/src/diagnostics/testing.rs
+++ b/crates/converter/src/diagnostics/testing.rs
@@ -259,18 +259,16 @@ fn descriptor_fields_match_evidence_keys() {
             !diags.is_empty(),
             "analyzer '{}' produced no diagnostics from fixture '{}' — \
              can't verify descriptor parity",
-            id, fixture_name,
+            id,
+            fixture_name,
         );
 
-        let descriptor_names: BTreeSet<String> = descriptor
-            .fields
-            .iter()
-            .map(|f| f.name.clone())
-            .collect();
+        let descriptor_names: BTreeSet<String> =
+            descriptor.fields.iter().map(|f| f.name.clone()).collect();
 
         for diag in &diags {
-            let evidence_json = serde_json::to_value(&diag.evidence)
-                .expect("Evidence must serialize");
+            let evidence_json =
+                serde_json::to_value(&diag.evidence).expect("Evidence must serialize");
             let evidence_obj = evidence_json
                 .as_object()
                 .expect("Evidence must serialize to JSON object");
@@ -282,7 +280,8 @@ fn descriptor_fields_match_evidence_keys() {
                 .collect();
 
             assert_eq!(
-                descriptor_names, evidence_names,
+                descriptor_names,
+                evidence_names,
                 "descriptor/evidence field mismatch for '{}'\n\
                  descriptor declares: {:?}\n\
                  evidence contains:   {:?}\n\
@@ -291,8 +290,12 @@ fn descriptor_fields_match_evidence_keys() {
                 id,
                 descriptor_names,
                 evidence_names,
-                evidence_names.difference(&descriptor_names).collect::<Vec<_>>(),
-                descriptor_names.difference(&evidence_names).collect::<Vec<_>>(),
+                evidence_names
+                    .difference(&descriptor_names)
+                    .collect::<Vec<_>>(),
+                descriptor_names
+                    .difference(&evidence_names)
+                    .collect::<Vec<_>>(),
             );
         }
 

--- a/crates/converter/src/metadata.rs
+++ b/crates/converter/src/metadata.rs
@@ -178,7 +178,6 @@ pub struct TopicInfo {
     pub multi_id: u8,
 }
 
-
 /// Extract metadata from a ULog file using the streaming parser.
 pub fn extract_metadata(path: &str) -> Result<FlightMetadata, std::io::Error> {
     let mut meta = FlightMetadata::default();
@@ -187,9 +186,9 @@ pub fn extract_metadata(path: &str) -> Result<FlightMetadata, std::io::Error> {
     let data = std::fs::read(path)?;
     if data.len() >= 16 {
         let mut parser = px4_ulog::stream_parser::LogParser::default();
-        parser.consume_bytes(&data[..16]).map_err(|e| {
-            std::io::Error::new(std::io::ErrorKind::InvalidData, format!("{}", e))
-        })?;
+        parser
+            .consume_bytes(&data[..16])
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, format!("{}", e)))?;
         meta.start_timestamp_us = parser.timestamp();
         meta.file_version = data[7];
     }
@@ -237,25 +236,31 @@ pub fn extract_metadata(path: &str) -> Result<FlightMetadata, std::io::Error> {
                 // Extract GPS first-fix from vehicle_gps_position
                 if meta.gps_first_fix.is_none() && topic == "vehicle_gps_position" {
                     // Try new field names (f64 degrees) first, fall back to legacy (i32 raw)
-                    let coords: Option<(f64, f64, f64)> =
-                        if let (Ok(lat_p), Ok(lon_p), Ok(alt_p)) = (
-                            data.flattened_format.get_field_parser::<f64>("latitude_deg"),
-                            data.flattened_format.get_field_parser::<f64>("longitude_deg"),
-                            data.flattened_format.get_field_parser::<f64>("altitude_msl_m"),
-                        ) {
-                            Some((lat_p.parse(data.data), lon_p.parse(data.data), alt_p.parse(data.data)))
-                        } else if let (Ok(lat_p), Ok(lon_p), Ok(alt_p)) = (
-                            data.flattened_format.get_field_parser::<i32>("lat"),
-                            data.flattened_format.get_field_parser::<i32>("lon"),
-                            data.flattened_format.get_field_parser::<i32>("alt"),
-                        ) {
-                            let lat = lat_p.parse(data.data);
-                            let lon = lon_p.parse(data.data);
-                            let alt = alt_p.parse(data.data);
-                            Some((lat as f64 * 1e-7, lon as f64 * 1e-7, alt as f64 * 1e-3))
-                        } else {
-                            None
-                        };
+                    let coords: Option<(f64, f64, f64)> = if let (Ok(lat_p), Ok(lon_p), Ok(alt_p)) = (
+                        data.flattened_format
+                            .get_field_parser::<f64>("latitude_deg"),
+                        data.flattened_format
+                            .get_field_parser::<f64>("longitude_deg"),
+                        data.flattened_format
+                            .get_field_parser::<f64>("altitude_msl_m"),
+                    ) {
+                        Some((
+                            lat_p.parse(data.data),
+                            lon_p.parse(data.data),
+                            alt_p.parse(data.data),
+                        ))
+                    } else if let (Ok(lat_p), Ok(lon_p), Ok(alt_p)) = (
+                        data.flattened_format.get_field_parser::<i32>("lat"),
+                        data.flattened_format.get_field_parser::<i32>("lon"),
+                        data.flattened_format.get_field_parser::<i32>("alt"),
+                    ) {
+                        let lat = lat_p.parse(data.data);
+                        let lon = lon_p.parse(data.data);
+                        let alt = alt_p.parse(data.data);
+                        Some((lat as f64 * 1e-7, lon as f64 * 1e-7, alt as f64 * 1e-3))
+                    } else {
+                        None
+                    };
 
                     if let Some((lat_deg, lon_deg, alt_m)) = coords {
                         if lat_deg != 0.0 && lon_deg != 0.0 {
@@ -375,9 +380,7 @@ pub fn extract_metadata(path: &str) -> Result<FlightMetadata, std::io::Error> {
                         }
                     }
                 }
-                let buffer = multi_info_buffers
-                    .entry(msg.key.to_string())
-                    .or_default();
+                let buffer = multi_info_buffers.entry(msg.key.to_string()).or_default();
                 // Each continued fragment is a separate line — add newline
                 // separator so they don't run together when displayed.
                 if !buffer.is_empty() && msg.is_continued {
@@ -434,8 +437,10 @@ mod tests {
     fn px4_ulog_fixture(name: &str) -> String {
         let manifest = env!("CARGO_MANIFEST_DIR");
         std::path::Path::new(manifest)
-            .parent().unwrap()  // crates/
-            .parent().unwrap()  // workspace root
+            .parent()
+            .unwrap() // crates/
+            .parent()
+            .unwrap() // workspace root
             .join("crates/converter/tests/fixtures")
             .join(name)
             .to_string_lossy()
@@ -501,7 +506,10 @@ mod tests {
         assert_eq!(meta.appended_offsets.len(), 3);
 
         // Derived fields
-        assert!(meta.flight_duration_s.unwrap() > 100.0, "Should have substantial flight duration");
+        assert!(
+            meta.flight_duration_s.unwrap() > 100.0,
+            "Should have substantial flight duration"
+        );
         assert_eq!(meta.ver_sw_release_str.as_deref(), Some("v1.14.4"));
 
         // GPS first fix
@@ -514,7 +522,10 @@ mod tests {
         assert!(meta.default_parameters.len() > 100);
 
         // Multi-info
-        assert!(!meta.multi_info.is_empty(), "Should have multi-info messages");
+        assert!(
+            !meta.multi_info.is_empty(),
+            "Should have multi-info messages"
+        );
         assert!(meta.multi_info.contains_key("metadata_events"));
     }
 
@@ -530,13 +541,18 @@ mod tests {
 
         // All major sections present in JSON
         for field in &[
-            "parameters", "logged_messages", "multi_info", "default_parameters",
-            "flight_duration_s", "ver_sw_release_str", "gps_first_fix",
-            "compat_flags", "incompat_flags", "file_version",
+            "parameters",
+            "logged_messages",
+            "multi_info",
+            "default_parameters",
+            "flight_duration_s",
+            "ver_sw_release_str",
+            "gps_first_fix",
+            "compat_flags",
+            "incompat_flags",
+            "file_version",
         ] {
             assert!(json.contains(field), "JSON should contain '{}'", field);
         }
     }
-
-
 }

--- a/crates/converter/src/signal_processing/mod.rs
+++ b/crates/converter/src/signal_processing/mod.rs
@@ -138,10 +138,8 @@ pub fn extract_signals(
             .push(req.field.as_str());
     }
 
-    let mut signals: HashMap<SignalRequest, TimeSeries> = requests
-        .iter()
-        .map(|r| (r.clone(), Vec::new()))
-        .collect();
+    let mut signals: HashMap<SignalRequest, TimeSeries> =
+        requests.iter().map(|r| (r.clone(), Vec::new())).collect();
 
     read_file_with_simple_callback(path, &mut |msg| {
         if let Message::Data(data) = msg {
@@ -158,9 +156,7 @@ pub fn extract_signals(
                     let t_s = ts as f64 / 1_000_000.0;
 
                     for &field in fields {
-                        if let Ok(parser) =
-                            data.flattened_format.get_field_parser::<f32>(field)
-                        {
+                        if let Ok(parser) = data.flattened_format.get_field_parser::<f32>(field) {
                             let val = parser.parse(data.data) as f64;
                             if val.is_finite() {
                                 let key = SignalRequest::new(topic, field);
@@ -193,10 +189,8 @@ pub fn run_analyses(
     analyses: &[Box<dyn SignalAnalysis>],
 ) -> Result<HashMap<String, serde_json::Value>, AnalysisError> {
     // Collect all required signals
-    let all_requests: HashSet<SignalRequest> = analyses
-        .iter()
-        .flat_map(|a| a.required_signals())
-        .collect();
+    let all_requests: HashSet<SignalRequest> =
+        analyses.iter().flat_map(|a| a.required_signals()).collect();
 
     // Single extraction pass
     let store = extract_signals(path, &all_requests)?;

--- a/crates/converter/src/signal_processing/pid_step_response.rs
+++ b/crates/converter/src/signal_processing/pid_step_response.rs
@@ -136,7 +136,11 @@ fn analyze_axis(
     }
 
     let t_start = setpoint_raw[0].0.max(gyro_raw[0].0);
-    let t_end = setpoint_raw.last().unwrap().0.min(gyro_raw.last().unwrap().0);
+    let t_end = setpoint_raw
+        .last()
+        .unwrap()
+        .0
+        .min(gyro_raw.last().unwrap().0);
     if t_end - t_start < WINDOW_DURATION_S {
         return None;
     }
@@ -247,10 +251,7 @@ fn wiener_step_response(
     fft.process(&mut x);
     fft.process(&mut y);
 
-    let max_power = x
-        .iter()
-        .map(|c| c.norm_sqr())
-        .fold(0.0f64, |a, b| a.max(b));
+    let max_power = x.iter().map(|c| c.norm_sqr()).fold(0.0f64, |a, b| a.max(b));
     if max_power < 1e-30 {
         return None;
     }
@@ -324,10 +325,7 @@ fn build_histogram(
             let ti = ((t - time_min) / time_bin_width).floor() as isize;
             let ai = ((val - HIST_AMP_MIN) / amp_bin_width).floor() as isize;
 
-            if ti >= 0
-                && (ti as usize) < HIST_TIME_BINS
-                && ai >= 0
-                && (ai as usize) < HIST_AMP_BINS
+            if ti >= 0 && (ti as usize) < HIST_TIME_BINS && ai >= 0 && (ai as usize) < HIST_AMP_BINS
             {
                 counts[ti as usize * HIST_AMP_BINS + ai as usize] += 1;
             }

--- a/crates/server/src/api/logs.rs
+++ b/crates/server/src/api/logs.rs
@@ -237,8 +237,7 @@ async fn lazy_convert(state: &crate::AppState, id: Uuid) -> Result<bool, ApiErro
     let file_size = ulg_data.len() as i64;
 
     // Write to temp file and convert
-    let tmp_dir =
-        tempfile::tempdir().map_err(|e| ApiError::Internal(format!("tempdir: {e}")))?;
+    let tmp_dir = tempfile::tempdir().map_err(|e| ApiError::Internal(format!("tempdir: {e}")))?;
     let input_path = tmp_dir.path().join("input.ulg");
     tokio::fs::write(&input_path, &ulg_data).await?;
 
@@ -276,10 +275,7 @@ async fn lazy_convert(state: &crate::AppState, id: Uuid) -> Result<bool, ApiErro
 
     // Copy the raw .ulg into the UUID directory so everything lives together
     let ulg_filename = format!("{}.ulg", id);
-    state
-        .storage
-        .put_file(id, &ulg_filename, ulg_data)
-        .await?;
+    state.storage.put_file(id, &ulg_filename, ulg_data).await?;
 
     // Update the DB record with fields extracted from the conversion
     if let Some(mut record) = state.db.get(id).await? {
@@ -290,7 +286,10 @@ async fn lazy_convert(state: &crate::AppState, id: Uuid) -> Result<bool, ApiErro
             .ver_sw_release_str
             .clone()
             .or(record.ver_sw_release_str);
-        record.flight_duration_s = result.metadata.flight_duration_s.or(record.flight_duration_s);
+        record.flight_duration_s = result
+            .metadata
+            .flight_duration_s
+            .or(record.flight_duration_s);
         record.topic_count = result.metadata.topics.len() as i32;
         record.lat = result
             .metadata
@@ -330,13 +329,9 @@ async fn lazy_convert(state: &crate::AppState, id: Uuid) -> Result<bool, ApiErro
             if let (Some(lat_val), Some(lon_val), Some(token)) =
                 (record.lat, record.lon, state.mapbox_token.as_deref())
             {
-                if let Some(name) = crate::geocode::reverse_geocode(
-                    &state.http_client,
-                    token,
-                    lat_val,
-                    lon_val,
-                )
-                .await
+                if let Some(name) =
+                    crate::geocode::reverse_geocode(&state.http_client, token, lat_val, lon_val)
+                        .await
                 {
                     tracing::info!(log_id = %id, location = %name, "geocoded location (lazy)");
                     record.location_name = Some(name);
@@ -387,9 +382,7 @@ fn parse_byte_range(range_str: &str) -> Result<(u64, u64), ApiError> {
     let range_spec = &range_str[bytes_prefix.len()..];
     let parts: Vec<&str> = range_spec.splitn(2, '-').collect();
     if parts.len() != 2 {
-        return Err(ApiError::BadRequest(format!(
-            "invalid range: {range_str}"
-        )));
+        return Err(ApiError::BadRequest(format!("invalid range: {range_str}")));
     }
 
     let start: u64 = parts[0]

--- a/crates/server/src/api/stats.rs
+++ b/crates/server/src/api/stats.rs
@@ -1,4 +1,7 @@
-use axum::{extract::{Query, State}, Json};
+use axum::{
+    extract::{Query, State},
+    Json,
+};
 use serde::Serialize;
 use std::sync::Arc;
 
@@ -34,10 +37,7 @@ pub async fn get_stats(
         )));
     }
 
-    let period_str = params
-        .period
-        .clone()
-        .unwrap_or_else(|| "30d".to_string());
+    let period_str = params.period.clone().unwrap_or_else(|| "30d".to_string());
 
     let data = state.db.stats(&params).await?;
 

--- a/crates/server/src/api/upload.rs
+++ b/crates/server/src/api/upload.rs
@@ -31,10 +31,7 @@ pub async fn upload(
         .map_err(|e| ApiError::BadRequest(format!("multipart error: {e}")))?
     {
         if field.name() == Some("file") {
-            let filename = field
-                .file_name()
-                .unwrap_or("upload.ulg")
-                .to_string();
+            let filename = field.file_name().unwrap_or("upload.ulg").to_string();
             let data = field
                 .bytes()
                 .await
@@ -125,11 +122,10 @@ pub async fn upload(
     // 5b. Reverse-geocode if location_name was not provided by the user
     let lat = result.metadata.gps_first_fix.as_ref().map(|g| g.lat_deg);
     let lon = result.metadata.gps_first_fix.as_ref().map(|g| g.lon_deg);
-    let user_gave_location = location_name
-        .as_ref()
-        .is_some_and(|s| !s.trim().is_empty());
+    let user_gave_location = location_name.as_ref().is_some_and(|s| !s.trim().is_empty());
     if !user_gave_location {
-        if let (Some(lat_val), Some(lon_val), Some(token)) = (lat, lon, state.mapbox_token.as_deref())
+        if let (Some(lat_val), Some(lon_val), Some(token)) =
+            (lat, lon, state.mapbox_token.as_deref())
         {
             match crate::geocode::reverse_geocode(&state.http_client, token, lat_val, lon_val).await
             {
@@ -216,7 +212,9 @@ pub async fn upload(
                     summary: d.summary.clone(),
                     timestamp_us: Some(d.timestamp_us as i64),
                     end_timestamp_us: match &d.kind {
-                        flight_review::diagnostics::AnomalyKind::Region { end_timestamp_us } => Some(*end_timestamp_us as i64),
+                        flight_review::diagnostics::AnomalyKind::Region { end_timestamp_us } => {
+                            Some(*end_timestamp_us as i64)
+                        }
                         flight_review::diagnostics::AnomalyKind::Point => None,
                     },
                     evidence: serde_json::to_string(&d.evidence).ok(),

--- a/crates/server/src/db/mod.rs
+++ b/crates/server/src/db/mod.rs
@@ -337,12 +337,28 @@ pub trait LogStore: Send + Sync {
     async fn stats(&self, params: &StatsParams) -> Result<Vec<StatRow>, DbError>;
 
     // Junction table methods
-    async fn insert_parameters(&self, log_id: Uuid, params: &[(String, f64)]) -> Result<(), DbError>;
+    async fn insert_parameters(
+        &self,
+        log_id: Uuid,
+        params: &[(String, f64)],
+    ) -> Result<(), DbError>;
     async fn insert_topics(&self, log_id: Uuid, topics: &[(String, i32)]) -> Result<(), DbError>;
     async fn insert_tags(&self, log_id: Uuid, tags: &[String]) -> Result<(), DbError>;
-    async fn insert_errors(&self, log_id: Uuid, errors: &[(String, String, Option<u64>)]) -> Result<(), DbError>;
-    async fn insert_field_stats(&self, log_id: Uuid, stats: &[FieldStatRecord]) -> Result<(), DbError>;
-    async fn insert_diagnostics(&self, log_id: Uuid, diagnostics: &[DiagnosticRecord]) -> Result<(), DbError>;
+    async fn insert_errors(
+        &self,
+        log_id: Uuid,
+        errors: &[(String, String, Option<u64>)],
+    ) -> Result<(), DbError>;
+    async fn insert_field_stats(
+        &self,
+        log_id: Uuid,
+        stats: &[FieldStatRecord],
+    ) -> Result<(), DbError>;
+    async fn insert_diagnostics(
+        &self,
+        log_id: Uuid,
+        diagnostics: &[DiagnosticRecord],
+    ) -> Result<(), DbError>;
     async fn delete_junction_data(&self, log_id: Uuid) -> Result<(), DbError>;
 }
 
@@ -364,7 +380,12 @@ pub fn bounding_box(lat: f64, lon: f64, radius_km: f64) -> (f64, f64, f64, f64) 
     } else {
         radius_km / (111.32 * cos_lat)
     };
-    (lat - lat_delta, lat + lat_delta, lon - lon_delta, lon + lon_delta)
+    (
+        lat - lat_delta,
+        lat + lat_delta,
+        lon - lon_delta,
+        lon + lon_delta,
+    )
 }
 
 /// A record for the `log_diagnostics` junction table.

--- a/crates/server/src/db/postgres.rs
+++ b/crates/server/src/db/postgres.rs
@@ -1,4 +1,6 @@
-use super::{DbError, FacetsResponse, ListFilters, ListResponse, LogRecord, LogStore, StatRow, StatsParams};
+use super::{
+    DbError, FacetsResponse, ListFilters, ListResponse, LogRecord, LogStore, StatRow, StatsParams,
+};
 use uuid::Uuid;
 
 #[cfg(feature = "postgres")]
@@ -156,10 +158,7 @@ pub struct PostgresStore {
 #[cfg(feature = "postgres")]
 impl PostgresStore {
     pub async fn new(url: &str) -> Result<Self, DbError> {
-        let pool = PgPoolOptions::new()
-            .max_connections(5)
-            .connect(url)
-            .await?;
+        let pool = PgPoolOptions::new().max_connections(5).connect(url).await?;
 
         sqlx::raw_sql(CREATE_TABLE).execute(&pool).await?;
 
@@ -575,7 +574,10 @@ impl LogStore for PostgresStore {
         // Data query
         let data_sql = format!(
             "SELECT * FROM logs {} ORDER BY {} LIMIT ${} OFFSET ${}",
-            where_clause, order_by, param_idx, param_idx + 1
+            where_clause,
+            order_by,
+            param_idx,
+            param_idx + 1
         );
         let mut data_query = sqlx::query(&data_sql);
         for v in &bind_values {
@@ -584,19 +586,20 @@ impl LogStore for PostgresStore {
         data_query = data_query.bind(limit).bind(offset);
 
         let rows = data_query.fetch_all(&self.pool).await?;
-        let logs: Result<Vec<LogRecord>, sqlx::Error> =
-            rows.iter().map(row_to_record).collect();
+        let logs: Result<Vec<LogRecord>, sqlx::Error> = rows.iter().map(row_to_record).collect();
 
-        Ok(ListResponse {
-            logs: logs?,
-            total,
-        })
+        Ok(ListResponse { logs: logs?, total })
     }
 
     async fn facets(&self, filters: &ListFilters) -> Result<FacetsResponse, DbError> {
         let (where_clause, bind_values, _param_idx) = build_where_postgres(filters);
 
-        let columns = ["ver_hw", "vehicle_type", "ver_sw_release_str", "vibration_status"];
+        let columns = [
+            "ver_hw",
+            "vehicle_type",
+            "ver_sw_release_str",
+            "vibration_status",
+        ];
         let mut results: Vec<Vec<String>> = Vec::new();
 
         for col in &columns {
@@ -610,7 +613,10 @@ impl LogStore for PostgresStore {
                 query = query.bind(v);
             }
             let rows = query.fetch_all(&self.pool).await?;
-            let vals: Vec<String> = rows.iter().filter_map(|r| r.try_get::<String, _>(col).ok()).collect();
+            let vals: Vec<String> = rows
+                .iter()
+                .filter_map(|r| r.try_get::<String, _>(col).ok())
+                .collect();
             results.push(vals);
         }
 
@@ -618,7 +624,9 @@ impl LogStore for PostgresStore {
         let tags_sql = if where_clause.is_empty() {
             "SELECT DISTINCT tags FROM logs WHERE tags IS NOT NULL AND tags != ''".to_string()
         } else {
-            format!("SELECT DISTINCT tags FROM logs {where_clause} AND tags IS NOT NULL AND tags != ''")
+            format!(
+                "SELECT DISTINCT tags FROM logs {where_clause} AND tags IS NOT NULL AND tags != ''"
+            )
         };
         let mut tags_query = sqlx::query(&tags_sql);
         for v in &bind_values {
@@ -799,17 +807,21 @@ impl LogStore for PostgresStore {
         Ok(data)
     }
 
-    async fn insert_parameters(&self, log_id: Uuid, params: &[(String, f64)]) -> Result<(), DbError> {
+    async fn insert_parameters(
+        &self,
+        log_id: Uuid,
+        params: &[(String, f64)],
+    ) -> Result<(), DbError> {
         for (name, value) in params {
             sqlx::query(
                 "INSERT INTO log_parameters (log_id, name, value) VALUES ($1, $2, $3) \
-                 ON CONFLICT (log_id, name) DO UPDATE SET value = EXCLUDED.value"
+                 ON CONFLICT (log_id, name) DO UPDATE SET value = EXCLUDED.value",
             )
-                .bind(log_id)
-                .bind(name)
-                .bind(value)
-                .execute(&self.pool)
-                .await?;
+            .bind(log_id)
+            .bind(name)
+            .bind(value)
+            .execute(&self.pool)
+            .await?;
         }
         Ok(())
     }
@@ -833,17 +845,21 @@ impl LogStore for PostgresStore {
         for tag in tags {
             sqlx::query(
                 "INSERT INTO log_tags (log_id, tag) VALUES ($1, $2) \
-                 ON CONFLICT (log_id, tag) DO NOTHING"
+                 ON CONFLICT (log_id, tag) DO NOTHING",
             )
-                .bind(log_id)
-                .bind(tag)
-                .execute(&self.pool)
-                .await?;
+            .bind(log_id)
+            .bind(tag)
+            .execute(&self.pool)
+            .await?;
         }
         Ok(())
     }
 
-    async fn insert_errors(&self, log_id: Uuid, errors: &[(String, String, Option<u64>)]) -> Result<(), DbError> {
+    async fn insert_errors(
+        &self,
+        log_id: Uuid,
+        errors: &[(String, String, Option<u64>)],
+    ) -> Result<(), DbError> {
         for (level, message, timestamp_us) in errors {
             sqlx::query(
                 "INSERT INTO log_errors (log_id, level, message, timestamp_us) VALUES ($1, $2, $3, $4)"
@@ -858,7 +874,11 @@ impl LogStore for PostgresStore {
         Ok(())
     }
 
-    async fn insert_field_stats(&self, log_id: Uuid, stats: &[super::FieldStatRecord]) -> Result<(), DbError> {
+    async fn insert_field_stats(
+        &self,
+        log_id: Uuid,
+        stats: &[super::FieldStatRecord],
+    ) -> Result<(), DbError> {
         for s in stats {
             sqlx::query(
                 "INSERT INTO log_field_stats (log_id, topic, field, min_val, max_val, mean_val, count) \
@@ -880,7 +900,11 @@ impl LogStore for PostgresStore {
         Ok(())
     }
 
-    async fn insert_diagnostics(&self, log_id: Uuid, diagnostics: &[super::DiagnosticRecord]) -> Result<(), DbError> {
+    async fn insert_diagnostics(
+        &self,
+        log_id: Uuid,
+        diagnostics: &[super::DiagnosticRecord],
+    ) -> Result<(), DbError> {
         for d in diagnostics {
             sqlx::query(
                 "INSERT INTO log_diagnostics (log_id, diagnostic_id, severity, summary, timestamp_us, end_timestamp_us, evidence) \
@@ -900,12 +924,30 @@ impl LogStore for PostgresStore {
     }
 
     async fn delete_junction_data(&self, log_id: Uuid) -> Result<(), DbError> {
-        sqlx::query("DELETE FROM log_parameters WHERE log_id = $1").bind(log_id).execute(&self.pool).await?;
-        sqlx::query("DELETE FROM log_topics WHERE log_id = $1").bind(log_id).execute(&self.pool).await?;
-        sqlx::query("DELETE FROM log_tags WHERE log_id = $1").bind(log_id).execute(&self.pool).await?;
-        sqlx::query("DELETE FROM log_errors WHERE log_id = $1").bind(log_id).execute(&self.pool).await?;
-        sqlx::query("DELETE FROM log_field_stats WHERE log_id = $1").bind(log_id).execute(&self.pool).await?;
-        sqlx::query("DELETE FROM log_diagnostics WHERE log_id = $1").bind(log_id).execute(&self.pool).await?;
+        sqlx::query("DELETE FROM log_parameters WHERE log_id = $1")
+            .bind(log_id)
+            .execute(&self.pool)
+            .await?;
+        sqlx::query("DELETE FROM log_topics WHERE log_id = $1")
+            .bind(log_id)
+            .execute(&self.pool)
+            .await?;
+        sqlx::query("DELETE FROM log_tags WHERE log_id = $1")
+            .bind(log_id)
+            .execute(&self.pool)
+            .await?;
+        sqlx::query("DELETE FROM log_errors WHERE log_id = $1")
+            .bind(log_id)
+            .execute(&self.pool)
+            .await?;
+        sqlx::query("DELETE FROM log_field_stats WHERE log_id = $1")
+            .bind(log_id)
+            .execute(&self.pool)
+            .await?;
+        sqlx::query("DELETE FROM log_diagnostics WHERE log_id = $1")
+            .bind(log_id)
+            .execute(&self.pool)
+            .await?;
         Ok(())
     }
 }
@@ -949,7 +991,11 @@ impl LogStore for PostgresStore {
         )))
     }
 
-    async fn insert_parameters(&self, _log_id: Uuid, _params: &[(String, f64)]) -> Result<(), DbError> {
+    async fn insert_parameters(
+        &self,
+        _log_id: Uuid,
+        _params: &[(String, f64)],
+    ) -> Result<(), DbError> {
         Err(DbError::Sqlx(sqlx::Error::Configuration(
             "postgres feature is not enabled".into(),
         )))
@@ -967,19 +1013,31 @@ impl LogStore for PostgresStore {
         )))
     }
 
-    async fn insert_errors(&self, _log_id: Uuid, _errors: &[(String, String, Option<u64>)]) -> Result<(), DbError> {
+    async fn insert_errors(
+        &self,
+        _log_id: Uuid,
+        _errors: &[(String, String, Option<u64>)],
+    ) -> Result<(), DbError> {
         Err(DbError::Sqlx(sqlx::Error::Configuration(
             "postgres feature is not enabled".into(),
         )))
     }
 
-    async fn insert_field_stats(&self, _log_id: Uuid, _stats: &[super::FieldStatRecord]) -> Result<(), DbError> {
+    async fn insert_field_stats(
+        &self,
+        _log_id: Uuid,
+        _stats: &[super::FieldStatRecord],
+    ) -> Result<(), DbError> {
         Err(DbError::Sqlx(sqlx::Error::Configuration(
             "postgres feature is not enabled".into(),
         )))
     }
 
-    async fn insert_diagnostics(&self, _log_id: Uuid, _diagnostics: &[super::DiagnosticRecord]) -> Result<(), DbError> {
+    async fn insert_diagnostics(
+        &self,
+        _log_id: Uuid,
+        _diagnostics: &[super::DiagnosticRecord],
+    ) -> Result<(), DbError> {
         Err(DbError::Sqlx(sqlx::Error::Configuration(
             "postgres feature is not enabled".into(),
         )))

--- a/crates/server/src/db/sqlite.rs
+++ b/crates/server/src/db/sqlite.rs
@@ -1,5 +1,8 @@
 #[cfg(feature = "sqlite")]
-use super::{period_to_days, DbError, FacetsResponse, ListFilters, ListResponse, LogRecord, LogStore, StatRow, StatsParams};
+use super::{
+    period_to_days, DbError, FacetsResponse, ListFilters, ListResponse, LogRecord, LogStore,
+    StatRow, StatsParams,
+};
 #[cfg(feature = "sqlite")]
 use chrono::{DateTime, Utc};
 #[cfg(feature = "sqlite")]
@@ -168,7 +171,9 @@ impl SqliteStore {
             .await?;
 
         // Enable foreign key support for cascade deletes.
-        sqlx::query("PRAGMA foreign_keys = ON").execute(&pool).await?;
+        sqlx::query("PRAGMA foreign_keys = ON")
+            .execute(&pool)
+            .await?;
 
         sqlx::query(CREATE_TABLE).execute(&pool).await?;
 
@@ -377,7 +382,8 @@ fn build_where_sqlite(filters: &ListFilters) -> (String, Vec<String>) {
     }
     if let Some(ref topic) = filters.has_topic {
         conditions.push(
-            "EXISTS (SELECT 1 FROM log_topics WHERE log_id = logs.id AND topic_name = ?)".to_string(),
+            "EXISTS (SELECT 1 FROM log_topics WHERE log_id = logs.id AND topic_name = ?)"
+                .to_string(),
         );
         bind_values.push(topic.clone());
     }
@@ -393,14 +399,14 @@ fn build_where_sqlite(filters: &ListFilters) -> (String, Vec<String>) {
         }
     }
     if let Some(ref tag) = filters.tag {
-        conditions.push(
-            "EXISTS (SELECT 1 FROM log_tags WHERE log_id = logs.id AND tag = ?)".to_string(),
-        );
+        conditions
+            .push("EXISTS (SELECT 1 FROM log_tags WHERE log_id = logs.id AND tag = ?)".to_string());
         bind_values.push(tag.clone());
     }
     if let Some(ref err_msg) = filters.error_message {
         conditions.push(
-            "EXISTS (SELECT 1 FROM log_errors WHERE log_id = logs.id AND message LIKE ?)".to_string(),
+            "EXISTS (SELECT 1 FROM log_errors WHERE log_id = logs.id AND message LIKE ?)"
+                .to_string(),
         );
         bind_values.push(format!("%{}%", err_msg));
     }
@@ -567,19 +573,20 @@ impl LogStore for SqliteStore {
         data_query = data_query.bind(limit).bind(offset);
 
         let rows = data_query.fetch_all(&self.pool).await?;
-        let logs: Result<Vec<LogRecord>, sqlx::Error> =
-            rows.iter().map(row_to_record).collect();
+        let logs: Result<Vec<LogRecord>, sqlx::Error> = rows.iter().map(row_to_record).collect();
 
-        Ok(ListResponse {
-            logs: logs?,
-            total,
-        })
+        Ok(ListResponse { logs: logs?, total })
     }
 
     async fn facets(&self, filters: &ListFilters) -> Result<FacetsResponse, DbError> {
         let (where_clause, bind_values) = build_where_sqlite(filters);
 
-        let columns = ["ver_hw", "vehicle_type", "ver_sw_release_str", "vibration_status"];
+        let columns = [
+            "ver_hw",
+            "vehicle_type",
+            "ver_sw_release_str",
+            "vibration_status",
+        ];
         let mut results: Vec<Vec<String>> = Vec::new();
 
         for col in &columns {
@@ -593,7 +600,10 @@ impl LogStore for SqliteStore {
                 query = query.bind(v);
             }
             let rows = query.fetch_all(&self.pool).await?;
-            let vals: Vec<String> = rows.iter().filter_map(|r| r.try_get::<String, _>(col).ok()).collect();
+            let vals: Vec<String> = rows
+                .iter()
+                .filter_map(|r| r.try_get::<String, _>(col).ok())
+                .collect();
             results.push(vals);
         }
 
@@ -601,7 +611,9 @@ impl LogStore for SqliteStore {
         let tags_sql = if where_clause.is_empty() {
             "SELECT DISTINCT tags FROM logs WHERE tags IS NOT NULL AND tags != ''".to_string()
         } else {
-            format!("SELECT DISTINCT tags FROM logs {where_clause} AND tags IS NOT NULL AND tags != ''")
+            format!(
+                "SELECT DISTINCT tags FROM logs {where_clause} AND tags IS NOT NULL AND tags != ''"
+            )
         };
         let mut tags_query = sqlx::query(&tags_sql);
         for v in &bind_values {
@@ -706,10 +718,7 @@ impl LogStore for SqliteStore {
 
         // Period filter
         if let Some(days) = period_to_days(params.period.as_deref()) {
-            conditions.push(format!(
-                "created_at >= datetime('now', '-{} days')",
-                days
-            ));
+            conditions.push(format!("created_at >= datetime('now', '-{} days')", days));
         }
 
         // Optional filters
@@ -774,15 +783,21 @@ impl LogStore for SqliteStore {
         Ok(data)
     }
 
-    async fn insert_parameters(&self, log_id: Uuid, params: &[(String, f64)]) -> Result<(), DbError> {
+    async fn insert_parameters(
+        &self,
+        log_id: Uuid,
+        params: &[(String, f64)],
+    ) -> Result<(), DbError> {
         let id_str = log_id.to_string();
         for (name, value) in params {
-            sqlx::query("INSERT OR REPLACE INTO log_parameters (log_id, name, value) VALUES (?, ?, ?)")
-                .bind(&id_str)
-                .bind(name)
-                .bind(value)
-                .execute(&self.pool)
-                .await?;
+            sqlx::query(
+                "INSERT OR REPLACE INTO log_parameters (log_id, name, value) VALUES (?, ?, ?)",
+            )
+            .bind(&id_str)
+            .bind(name)
+            .bind(value)
+            .execute(&self.pool)
+            .await?;
         }
         Ok(())
     }
@@ -812,21 +827,31 @@ impl LogStore for SqliteStore {
         Ok(())
     }
 
-    async fn insert_errors(&self, log_id: Uuid, errors: &[(String, String, Option<u64>)]) -> Result<(), DbError> {
+    async fn insert_errors(
+        &self,
+        log_id: Uuid,
+        errors: &[(String, String, Option<u64>)],
+    ) -> Result<(), DbError> {
         let id_str = log_id.to_string();
         for (level, message, timestamp_us) in errors {
-            sqlx::query("INSERT INTO log_errors (log_id, level, message, timestamp_us) VALUES (?, ?, ?, ?)")
-                .bind(&id_str)
-                .bind(level)
-                .bind(message)
-                .bind(timestamp_us.map(|t| t as i64))
-                .execute(&self.pool)
-                .await?;
+            sqlx::query(
+                "INSERT INTO log_errors (log_id, level, message, timestamp_us) VALUES (?, ?, ?, ?)",
+            )
+            .bind(&id_str)
+            .bind(level)
+            .bind(message)
+            .bind(timestamp_us.map(|t| t as i64))
+            .execute(&self.pool)
+            .await?;
         }
         Ok(())
     }
 
-    async fn insert_field_stats(&self, log_id: Uuid, stats: &[super::FieldStatRecord]) -> Result<(), DbError> {
+    async fn insert_field_stats(
+        &self,
+        log_id: Uuid,
+        stats: &[super::FieldStatRecord],
+    ) -> Result<(), DbError> {
         let id_str = log_id.to_string();
         for s in stats {
             sqlx::query(
@@ -846,7 +871,11 @@ impl LogStore for SqliteStore {
         Ok(())
     }
 
-    async fn insert_diagnostics(&self, log_id: Uuid, diagnostics: &[super::DiagnosticRecord]) -> Result<(), DbError> {
+    async fn insert_diagnostics(
+        &self,
+        log_id: Uuid,
+        diagnostics: &[super::DiagnosticRecord],
+    ) -> Result<(), DbError> {
         let id_str = log_id.to_string();
         for d in diagnostics {
             sqlx::query(
@@ -868,12 +897,30 @@ impl LogStore for SqliteStore {
 
     async fn delete_junction_data(&self, log_id: Uuid) -> Result<(), DbError> {
         let id_str = log_id.to_string();
-        sqlx::query("DELETE FROM log_parameters WHERE log_id = ?").bind(&id_str).execute(&self.pool).await?;
-        sqlx::query("DELETE FROM log_topics WHERE log_id = ?").bind(&id_str).execute(&self.pool).await?;
-        sqlx::query("DELETE FROM log_tags WHERE log_id = ?").bind(&id_str).execute(&self.pool).await?;
-        sqlx::query("DELETE FROM log_errors WHERE log_id = ?").bind(&id_str).execute(&self.pool).await?;
-        sqlx::query("DELETE FROM log_field_stats WHERE log_id = ?").bind(&id_str).execute(&self.pool).await?;
-        sqlx::query("DELETE FROM log_diagnostics WHERE log_id = ?").bind(&id_str).execute(&self.pool).await?;
+        sqlx::query("DELETE FROM log_parameters WHERE log_id = ?")
+            .bind(&id_str)
+            .execute(&self.pool)
+            .await?;
+        sqlx::query("DELETE FROM log_topics WHERE log_id = ?")
+            .bind(&id_str)
+            .execute(&self.pool)
+            .await?;
+        sqlx::query("DELETE FROM log_tags WHERE log_id = ?")
+            .bind(&id_str)
+            .execute(&self.pool)
+            .await?;
+        sqlx::query("DELETE FROM log_errors WHERE log_id = ?")
+            .bind(&id_str)
+            .execute(&self.pool)
+            .await?;
+        sqlx::query("DELETE FROM log_field_stats WHERE log_id = ?")
+            .bind(&id_str)
+            .execute(&self.pool)
+            .await?;
+        sqlx::query("DELETE FROM log_diagnostics WHERE log_id = ?")
+            .bind(&id_str)
+            .execute(&self.pool)
+            .await?;
         Ok(())
     }
 }
@@ -908,49 +955,80 @@ impl super::LogStore for SqliteStore {
         )))
     }
 
-    async fn update(&self, _id: uuid::Uuid, _record: &super::LogRecord) -> Result<(), super::DbError> {
+    async fn update(
+        &self,
+        _id: uuid::Uuid,
+        _record: &super::LogRecord,
+    ) -> Result<(), super::DbError> {
         Err(super::DbError::Sqlx(sqlx::Error::Configuration(
             "sqlite feature is not enabled".into(),
         )))
     }
 
-    async fn stats(&self, _params: &super::StatsParams) -> Result<Vec<super::StatRow>, super::DbError> {
+    async fn stats(
+        &self,
+        _params: &super::StatsParams,
+    ) -> Result<Vec<super::StatRow>, super::DbError> {
         Err(super::DbError::Sqlx(sqlx::Error::Configuration(
             "sqlite feature is not enabled".into(),
         )))
     }
 
-    async fn insert_parameters(&self, _log_id: uuid::Uuid, _params: &[(String, f64)]) -> Result<(), super::DbError> {
+    async fn insert_parameters(
+        &self,
+        _log_id: uuid::Uuid,
+        _params: &[(String, f64)],
+    ) -> Result<(), super::DbError> {
         Err(super::DbError::Sqlx(sqlx::Error::Configuration(
             "sqlite feature is not enabled".into(),
         )))
     }
 
-    async fn insert_topics(&self, _log_id: uuid::Uuid, _topics: &[(String, i32)]) -> Result<(), super::DbError> {
+    async fn insert_topics(
+        &self,
+        _log_id: uuid::Uuid,
+        _topics: &[(String, i32)],
+    ) -> Result<(), super::DbError> {
         Err(super::DbError::Sqlx(sqlx::Error::Configuration(
             "sqlite feature is not enabled".into(),
         )))
     }
 
-    async fn insert_tags(&self, _log_id: uuid::Uuid, _tags: &[String]) -> Result<(), super::DbError> {
+    async fn insert_tags(
+        &self,
+        _log_id: uuid::Uuid,
+        _tags: &[String],
+    ) -> Result<(), super::DbError> {
         Err(super::DbError::Sqlx(sqlx::Error::Configuration(
             "sqlite feature is not enabled".into(),
         )))
     }
 
-    async fn insert_errors(&self, _log_id: uuid::Uuid, _errors: &[(String, String, Option<u64>)]) -> Result<(), super::DbError> {
+    async fn insert_errors(
+        &self,
+        _log_id: uuid::Uuid,
+        _errors: &[(String, String, Option<u64>)],
+    ) -> Result<(), super::DbError> {
         Err(super::DbError::Sqlx(sqlx::Error::Configuration(
             "sqlite feature is not enabled".into(),
         )))
     }
 
-    async fn insert_field_stats(&self, _log_id: uuid::Uuid, _stats: &[super::FieldStatRecord]) -> Result<(), super::DbError> {
+    async fn insert_field_stats(
+        &self,
+        _log_id: uuid::Uuid,
+        _stats: &[super::FieldStatRecord],
+    ) -> Result<(), super::DbError> {
         Err(super::DbError::Sqlx(sqlx::Error::Configuration(
             "sqlite feature is not enabled".into(),
         )))
     }
 
-    async fn insert_diagnostics(&self, _log_id: uuid::Uuid, _diagnostics: &[super::DiagnosticRecord]) -> Result<(), super::DbError> {
+    async fn insert_diagnostics(
+        &self,
+        _log_id: uuid::Uuid,
+        _diagnostics: &[super::DiagnosticRecord],
+    ) -> Result<(), super::DbError> {
         Err(super::DbError::Sqlx(sqlx::Error::Configuration(
             "sqlite feature is not enabled".into(),
         )))
@@ -962,7 +1040,10 @@ impl super::LogStore for SqliteStore {
         )))
     }
 
-    async fn facets(&self, _filters: &super::ListFilters) -> Result<super::FacetsResponse, super::DbError> {
+    async fn facets(
+        &self,
+        _filters: &super::ListFilters,
+    ) -> Result<super::FacetsResponse, super::DbError> {
         Err(super::DbError::Sqlx(sqlx::Error::Configuration(
             "sqlite feature is not enabled".into(),
         )))

--- a/crates/server/src/extract.rs
+++ b/crates/server/src/extract.rs
@@ -203,8 +203,10 @@ mod tests {
 
         // First: check local fixtures in the converter crate
         let local = std::path::Path::new(manifest)
-            .parent().unwrap()  // crates/
-            .parent().unwrap()  // workspace root
+            .parent()
+            .unwrap() // crates/
+            .parent()
+            .unwrap() // workspace root
             .join("crates/converter/tests/fixtures")
             .join(name);
         if local.exists() {
@@ -213,9 +215,12 @@ mod tests {
 
         // Fallback: px4-ulog-rs repo (local dev)
         let external = std::path::Path::new(manifest)
-            .parent().unwrap()  // crates/
-            .parent().unwrap()  // workspace root
-            .parent().unwrap()  // ulog/
+            .parent()
+            .unwrap() // crates/
+            .parent()
+            .unwrap() // workspace root
+            .parent()
+            .unwrap() // ulog/
             .join("px4-ulog-rs/tests/fixtures")
             .join(name);
         external.to_string_lossy().to_string()
@@ -237,13 +242,11 @@ mod tests {
         // Should detect vehicle type from MAV_TYPE param
         assert!(fields.vehicle_type.is_some());
         // Should have GPS in localization
-        assert!(
-            fields
-                .localization_sources
-                .as_ref()
-                .unwrap()
-                .contains("GPS")
-        );
+        assert!(fields
+            .localization_sources
+            .as_ref()
+            .unwrap()
+            .contains("GPS"));
         // Should have vibration status
         assert!(fields.vibration_status.is_some());
         // Should have error/warning counts

--- a/crates/server/src/geocode.rs
+++ b/crates/server/src/geocode.rs
@@ -18,7 +18,7 @@ pub async fn reverse_geocode(
 
     let resp = tokio::time::timeout(Duration::from_secs(5), client.get(&url).send())
         .await
-        .ok()?  // timeout
+        .ok()? // timeout
         .ok()?; // request error
 
     if !resp.status().is_success() {
@@ -63,10 +63,7 @@ pub async fn reverse_geocode(
 
         // Extract country info from context on any feature
         if country_code.is_none() || country.is_none() {
-            if let Some(ctx) = props
-                .get("context")
-                .and_then(|c| c.get("country"))
-            {
+            if let Some(ctx) = props.get("context").and_then(|c| c.get("country")) {
                 if country_code.is_none() {
                     country_code = ctx
                         .get("country_code")
@@ -84,14 +81,12 @@ pub async fn reverse_geocode(
         (Some(p), Some(c)) => format!("{}, {}", p, c),
         (Some(p), None) => p.to_string(),
         (None, Some(c)) => c.to_string(),
-        (None, None) => {
-            features
-                .first()
-                .and_then(|f| f.get("properties"))
-                .and_then(|p| p.get("full_address"))
-                .and_then(|v| v.as_str())
-                .map(String::from)?
-        }
+        (None, None) => features
+            .first()
+            .and_then(|f| f.get("properties"))
+            .and_then(|p| p.get("full_address"))
+            .and_then(|v| v.as_str())
+            .map(String::from)?,
     };
 
     // Append country code if available: "City, Country [CC]"

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -104,9 +104,7 @@ async fn run_server(config: ServeConfig) {
     let db = db::create_db(&config.db)
         .await
         .expect("failed to connect to database");
-    let storage = Arc::new(
-        FileStorage::from_url(&config.storage).expect("failed to init storage"),
-    );
+    let storage = Arc::new(FileStorage::from_url(&config.storage).expect("failed to init storage"));
 
     let state = Arc::new(AppState {
         db,
@@ -124,9 +122,7 @@ async fn run_server(config: ServeConfig) {
         .expect("failed to bind listener");
 
     tracing::info!("server listening on {addr}");
-    axum::serve(listener, app)
-        .await
-        .expect("server error");
+    axum::serve(listener, app).await.expect("server error");
 }
 
 /// Map v1 MavType string to a normalized vehicle type category.
@@ -180,7 +176,7 @@ async fn run_migrate(config: MigrateConfig) {
             g.SoftwareVersion, g.NumLoggedErrors, g.NumLoggedWarnings, g.FlightModes, \
             g.FlightModeDurations, g.UUID, g.StartTime \
          FROM Logs l \
-         LEFT JOIN LogsGenerated g ON l.Id = g.Id"
+         LEFT JOIN LogsGenerated g ON l.Id = g.Id",
     )
     .fetch_all(&v1_pool)
     .await
@@ -251,9 +247,7 @@ async fn run_migrate(config: MigrateConfig) {
         let sys_name = hardware.clone().or(mav_type);
         let ver_hw = hardware;
         let ver_sw_release_str = software_version;
-        let flight_duration_s = duration_str
-            .as_deref()
-            .and_then(|s| s.parse::<f64>().ok());
+        let flight_duration_s = duration_str.as_deref().and_then(|s| s.parse::<f64>().ok());
 
         // Pilot-provided context fields from v1 Logs table
         let description: Option<String> = row.try_get("Description").ok().flatten();
@@ -327,7 +321,13 @@ async fn run_migrate(config: MigrateConfig) {
         }
 
         if (i + 1) % 1000 == 0 {
-            tracing::info!("Progress: {}/{} processed ({} imported, {} skipped)", i + 1, total, imported, skipped);
+            tracing::info!(
+                "Progress: {}/{} processed ({} imported, {} skipped)",
+                i + 1,
+                total,
+                imported,
+                skipped
+            );
         }
     }
 

--- a/crates/server/src/storage/mod.rs
+++ b/crates/server/src/storage/mod.rs
@@ -27,8 +27,7 @@ impl FileStorage {
         if url.starts_with("file://") {
             let path = url.strip_prefix("file://").unwrap();
             std::fs::create_dir_all(path)?;
-            let store =
-                LocalFileSystem::new_with_prefix(path)?;
+            let store = LocalFileSystem::new_with_prefix(path)?;
             Ok(Self {
                 store: Arc::new(store),
             })
@@ -36,8 +35,9 @@ impl FileStorage {
             #[cfg(feature = "s3")]
             {
                 let without_scheme = url.strip_prefix("s3://").unwrap();
-                let (bucket, prefix) =
-                    without_scheme.split_once('/').unwrap_or((without_scheme, ""));
+                let (bucket, prefix) = without_scheme
+                    .split_once('/')
+                    .unwrap_or((without_scheme, ""));
                 let s3 = object_store::aws::AmazonS3Builder::from_env()
                     .with_bucket_name(bucket)
                     .build()?;
@@ -93,11 +93,7 @@ impl FileStorage {
     }
 
     /// Get a file for a log.
-    pub async fn get_file(
-        &self,
-        log_id: Uuid,
-        filename: &str,
-    ) -> Result<Bytes, StorageError> {
+    pub async fn get_file(&self, log_id: Uuid, filename: &str) -> Result<Bytes, StorageError> {
         let path = Self::log_file_path(log_id, filename);
         let result = self.store.get(&path).await?;
         Ok(result.bytes().await?)

--- a/crates/server/tests/integration.rs
+++ b/crates/server/tests/integration.rs
@@ -19,8 +19,10 @@ fn fixture_path(name: &str) -> std::path::PathBuf {
 
     // First: check local fixtures in the converter crate
     let local = std::path::Path::new(manifest)
-        .parent().unwrap()  // crates/
-        .parent().unwrap()  // workspace root
+        .parent()
+        .unwrap() // crates/
+        .parent()
+        .unwrap() // workspace root
         .join("crates/converter/tests/fixtures")
         .join(name);
     if local.exists() {
@@ -29,9 +31,12 @@ fn fixture_path(name: &str) -> std::path::PathBuf {
 
     // Fallback: px4-ulog-rs repo (local dev)
     std::path::Path::new(manifest)
-        .parent().unwrap()  // crates/
-        .parent().unwrap()  // workspace root
-        .parent().unwrap()  // ulog/
+        .parent()
+        .unwrap() // crates/
+        .parent()
+        .unwrap() // workspace root
+        .parent()
+        .unwrap() // ulog/
         .join("px4-ulog-rs/tests/fixtures")
         .join(name)
 }
@@ -121,7 +126,10 @@ async fn test_full_lifecycle() {
             "version field '{field}' missing or empty: {body:?}"
         );
     }
-    assert_eq!(body["px4_ulog"], "0.6.1", "px4-ulog version should match Cargo.lock");
+    assert_eq!(
+        body["px4_ulog"], "0.6.1",
+        "px4-ulog version should match Cargo.lock"
+    );
 
     // 2. Upload a log
     let fixture = fixture_path("sample.ulg");
@@ -187,7 +195,10 @@ async fn test_full_lifecycle() {
 
     // 5. Get metadata.json
     let resp = client
-        .get(format!("{}/api/logs/{}/data/metadata.json", base_url, log_id))
+        .get(format!(
+            "{}/api/logs/{}/data/metadata.json",
+            base_url, log_id
+        ))
         .send()
         .await
         .unwrap();
@@ -219,10 +230,7 @@ async fn test_full_lifecycle() {
 
     // 7. Get raw .ulg file
     let resp = client
-        .get(format!(
-            "{}/api/logs/{}/data/sample.ulg",
-            base_url, log_id
-        ))
+        .get(format!("{}/api/logs/{}/data/sample.ulg", base_url, log_id))
         .send()
         .await
         .unwrap();
@@ -244,10 +252,7 @@ async fn test_full_lifecycle() {
 
     // 9. Search filters
     let resp = client
-        .get(format!(
-            "{}/api/logs?sys_name=PX4&has_gps=false",
-            base_url
-        ))
+        .get(format!("{}/api/logs?sys_name=PX4&has_gps=false", base_url))
         .send()
         .await
         .unwrap();
@@ -258,10 +263,7 @@ async fn test_full_lifecycle() {
 
     // 10. Delete with wrong token — should fail
     let resp = client
-        .delete(format!(
-            "{}/api/logs/{}?token=wrongtoken",
-            base_url, log_id
-        ))
+        .delete(format!("{}/api/logs/{}?token=wrongtoken", base_url, log_id))
         .send()
         .await
         .unwrap();


### PR DESCRIPTION
## Summary

Add a Rust formatting check to CI and apply the current `cargo fmt --all` output across the workspace.

This PR intentionally keeps the change split into two commits:

1. `Enforce Rust formatting in CI` adds `cargo fmt --all -- --check`.
2. `Format Rust sources` applies rustfmt so the new check passes at PR HEAD.

This makes future formatting drift visible in CI while keeping the formatting-only changes isolated from behavior changes.

## Testing

- `cargo fmt --all -- --check`

I also verified that the first commit alone fails the new check before the formatting commit, as expected.