### PR TITLE
feat(frontend): custom DuckDB SQL plots

### DIFF
--- a/frontend/src/lib/components/viewer/PlotBuilderPanel.svelte
+++ b/frontend/src/lib/components/viewer/PlotBuilderPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import type { FlightMetadata, PlotConfig, TopicInfo } from '$lib/types';
-	import { activePlots, plottedFields, builderOpen } from '$lib/stores/logViewer';
+	import { activePlots, plottedFields, builderOpen, editSqlPlot } from '$lib/stores/logViewer';
 	import { initDuckDB, LogSession } from '$lib/utils/duckdb';
 
 	let { metadata } = $props<{ metadata: FlightMetadata }>();
@@ -10,6 +10,75 @@
 
 	let searchQuery = $state('');
 	let expandedTopics = $state<Set<string>>(new Set());
+
+	// Raw SQL plot editor
+	const DEFAULT_SQL_LABEL = 'Custom SQL';
+	let sqlOpen = $state(false);
+	let sqlText = $state('');
+	let sqlName = $state('');
+	let sqlCounter = $state(0);
+	// Id of the SQL plot currently being edited (null = creating a new one).
+	let editingId = $state<string | null>(null);
+
+	// When another component requests editing a SQL plot, load it into the editor.
+	$effect(() => {
+		const target = $editSqlPlot;
+		if (!target) return;
+		editingId = target.id;
+		sqlText = target.sql ?? '';
+		sqlName = target.yLabel && target.yLabel !== DEFAULT_SQL_LABEL ? target.yLabel : '';
+		sqlOpen = true;
+		builderOpen.set(true);
+		editSqlPlot.set(null); // consume the request
+	});
+
+	function cancelEdit() {
+		editingId = null;
+		sqlText = '';
+		sqlName = '';
+	}
+
+	function insertSqlExample() {
+		const names = Object.keys(metadata.topics).sort((a, b) => a.localeCompare(b));
+		const topic = names.find((t) => /sensor_mag|sensor_accel|sensor_gyro/.test(t)) ?? names[0] ?? 'sensor_mag';
+		const multiId = metadata.topics[topic]?.multi_id ?? 0;
+		const file = multiId > 0 ? `${topic}_${multiId}` : topic;
+		sqlName = topic;
+		sqlText =
+			`SELECT timestamp, x, y, z\n` +
+			`FROM read_parquet('${file}')\n` +
+			`ORDER BY timestamp`;
+	}
+
+	function submitSqlPlot() {
+		const sql = sqlText.trim();
+		if (!sql) return;
+		const yLabel = sqlName.trim() || DEFAULT_SQL_LABEL;
+
+		if (editingId) {
+			// Update in place and stay in edit mode (populated editor) so further
+			// tweaks re-update the same plot; Cancel exits.
+			const id = editingId;
+			activePlots.update((plots) =>
+				plots.map((p) => (p.id === id ? { ...p, sql, yLabel } : p))
+			);
+		} else {
+			sqlCounter += 1;
+			const newPlot: PlotConfig = {
+				id: `sql_${Date.now()}_${sqlCounter}`,
+				topic: '',
+				multiId: 0,
+				fields: [],
+				yLabel,
+				colors: [],
+				kind: 'sql',
+				sql,
+			};
+			activePlots.update((plots) => [newPlot, ...plots]);
+			sqlText = '';
+			sqlName = '';
+		}
+	}
 
 	let topicFields = $state<Map<string, { name: string; type: string }[]>>(new Map());
 	let loadingTopics = $state<Set<string>>(new Set());
@@ -153,6 +222,69 @@
 
 			<!-- Content -->
 			<div class="flex-1 overflow-y-auto px-4 py-4">
+				<!-- Custom SQL plot -->
+				<div class="mb-4 rounded-md ring-1 ring-gray-200">
+					<button
+						type="button"
+						class="flex w-full items-center gap-2 px-3 py-2 text-sm font-medium text-gray-800 hover:bg-gray-50"
+						onclick={() => (sqlOpen = !sqlOpen)}
+						aria-expanded={sqlOpen}
+					>
+						<svg class="size-4 text-gray-400 transition-transform {sqlOpen ? 'rotate-90' : ''}" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+						</svg>
+						Custom SQL plot
+						<span class="ml-auto text-[10px] font-medium text-indigo-500 bg-indigo-50 rounded px-1.5 py-0.5">DuckDB</span>
+					</button>
+					{#if sqlOpen}
+						<div class="border-t border-gray-100 px-3 py-3 space-y-2">
+							<input
+								type="text"
+								placeholder="Plot name (optional)"
+								bind:value={sqlName}
+								class="block w-full rounded-md bg-white px-2 py-1 text-xs text-gray-900 placeholder:text-gray-400 ring-1 ring-gray-300 focus:ring-2 focus:ring-indigo-500 outline-none"
+							/>
+							<textarea
+								bind:value={sqlText}
+								rows="7"
+								spellcheck="false"
+								placeholder="SELECT timestamp, x, y, z FROM read_parquet('sensor_mag') ORDER BY timestamp"
+								class="block w-full rounded-md bg-gray-50 px-2 py-1.5 font-mono text-[11px] leading-snug text-gray-900 placeholder:text-gray-400 ring-1 ring-gray-300 focus:ring-2 focus:ring-indigo-500 outline-none resize-y"
+							></textarea>
+							<div class="flex items-center gap-2">
+								<button
+									type="button"
+									class="rounded-md bg-indigo-600 px-3 py-1 text-xs font-medium text-white hover:bg-indigo-500 disabled:opacity-40"
+									onclick={submitSqlPlot}
+									disabled={!sqlText.trim()}
+								>
+									{editingId ? 'Update plot' : 'Add plot'}
+								</button>
+								{#if editingId}
+									<button
+										type="button"
+										class="rounded-md px-2 py-1 text-xs font-medium text-gray-600 hover:text-gray-800"
+										onclick={cancelEdit}
+									>
+										Cancel
+									</button>
+								{:else}
+									<button
+										type="button"
+										class="rounded-md px-2 py-1 text-xs font-medium text-indigo-600 hover:text-indigo-500"
+										onclick={insertSqlExample}
+									>
+										Insert example
+									</button>
+								{/if}
+							</div>
+							<p class="text-[11px] leading-snug text-gray-500">
+								Name the time column exactly <code class="text-gray-700">timestamp</code> to get the shared seconds x-axis (synced with other plots) — don't alias it. Other numeric columns become series; a query with no <code class="text-gray-700">timestamp</code> uses its first column as a plain, independent x. Topics are Parquet files by name: <code class="text-gray-700">FROM read_parquet('sensor_mag')</code> (or <code class="text-gray-700">'sensor_mag.parquet'</code>; instance 1 is <code class="text-gray-700">'sensor_accel_1'</code>). In window frames, order by <code class="text-gray-700">CAST(timestamp AS BIGINT)</code> — raw timestamps are unsigned.
+							</p>
+						</div>
+					{/if}
+				</div>
+
 				<!-- Search -->
 				<div class="mb-4">
 					<input

--- a/frontend/src/lib/components/viewer/PlotStrip.svelte
+++ b/frontend/src/lib/components/viewer/PlotStrip.svelte
@@ -2,7 +2,7 @@
 	import { onMount, onDestroy } from 'svelte';
 	import uPlot from 'uplot';
 	import type { PlotConfig, FlightMetadata } from '$lib/types';
-	import { activePlots, togglePlotMinimized } from '$lib/stores/logViewer';
+	import { activePlots, togglePlotMinimized, editSqlPlot } from '$lib/stores/logViewer';
 	import { timeRange, setTimeRange, cursorTimestamp, SYNC_KEY } from '$lib/stores/plotSync';
 	import { initDuckDB, LogSession } from '$lib/utils/duckdb';
 	import { touchZoomPlugin } from '$lib/utils/uplotTouchZoom';
@@ -37,6 +37,15 @@
 	let error = $state<string | null>(null);
 	let plotHeight = $state(300);
 
+	// Series metadata actually rendered. For timeseries plots this mirrors
+	// config.fields/colors; for SQL plots it comes from the query result.
+	const PLOT_COLORS = ['#818cf8', '#fbbf24', '#34d399', '#f87171', '#a78bfa', '#fb923c', '#38bdf8', '#e879f9'];
+	let seriesLabels = $state<string[]>([]);
+	let seriesColors = $state<string[]>([]);
+	// Whether the x-axis is the shared seconds domain (SQL plots: only with a
+	// `timestamp` column). Non-time plots stay out of the time-range sync.
+	let timeSynced = $state(true);
+
 	// Guard against infinite loops when syncing scales
 	let settingScale = false;
 
@@ -45,8 +54,8 @@
 	let pendingSyncRange: [number, number] | null = null;
 	let intersectionObserver: IntersectionObserver | null = null;
 
-	// Track the fields key to detect changes
-	let lastFieldsKey = '';
+	// Track the render key (fields or SQL text) to detect changes
+	let lastRenderKey = '';
 
 	async function getSession(): Promise<LogSession> {
 		if (sessionCache.has(logId)) return sessionCache.get(logId)!;
@@ -60,37 +69,74 @@
 		activePlots.update((plots) => plots.filter((p) => p.id !== config.id));
 	}
 
+	function editSql() {
+		// Hand the config to the builder, which opens in edit mode.
+		editSqlPlot.set(config);
+	}
+
 	function downloadPng() {
 		if (!chartEl) return;
 		const canvas = chartEl.querySelector('canvas');
 		if (!canvas) return;
 		const link = document.createElement('a');
-		link.download = `${config.topic}.png`;
+		link.download = `${(config.topic || config.yLabel || 'plot').replace(/[^a-z0-9_-]+/gi, '_')}.png`;
 		link.href = canvas.toDataURL('image/png');
 		link.click();
 	}
 
-	async function loadAndRender(fields: string[], colors: string[]) {
-		const fieldsKey = fields.join(',');
-		if (fieldsKey === lastFieldsKey && uplot) return;
-		lastFieldsKey = fieldsKey;
+	function renderKey(): string {
+		// Include yLabel so renaming a plot rebuilds it and refreshes the y-axis label
+		const base = config.kind === 'sql' ? `sql:${config.sql ?? ''}` : config.fields.join(',');
+		return `${base}|y:${config.yLabel ?? ''}`;
+	}
+
+	async function loadAndRender() {
+		const key = renderKey();
+		if (key === lastRenderKey && uplot) return;
+		lastRenderKey = key;
 
 		loading = true;
 		error = null;
 
 		try {
 			const session = await getSession();
-			const result = await session.queryTopic(config.topic, fields, {
-				multiId: config.multiId
-			});
 
-			if (!result) {
-				// Auto-remove plots with no data (e.g. field names don't exist in this log version)
-				removePlot();
-				return;
+			let xData: Float64Array;
+			let series: Float64Array[];
+			let labels: string[];
+
+			if (config.kind === 'sql') {
+				const result = await session.querySql(config.sql ?? '');
+				if (!result) {
+					// Don't auto-remove a user's SQL plot on an empty result — surface it.
+					error = 'Query returned no rows.';
+					loading = false;
+					return;
+				}
+				xData = result.x;
+				series = result.series;
+				labels = result.labels;
+				timeSynced = result.xIsTime;
+			} else {
+				const result = await session.queryTopic(config.topic, config.fields, {
+					multiId: config.multiId
+				});
+				if (!result) {
+					// Auto-remove plots with no data (e.g. field names don't exist in this log version)
+					removePlot();
+					return;
+				}
+				xData = result.timestamps;
+				series = result.series;
+				labels = config.fields;
+				timeSynced = true;
 			}
 
-			const data: uPlot.AlignedData = [result.timestamps, ...result.series];
+			const colors = labels.map((_, i) => config.colors[i] ?? PLOT_COLORS[i % PLOT_COLORS.length]);
+			seriesLabels = labels;
+			seriesColors = colors;
+
+			const data: uPlot.AlignedData = [xData, ...series];
 
 			// clientWidth is the post-layout, clip-aware inner width, so the plot
 			// is never created wider than the column actually allows.
@@ -113,7 +159,8 @@
 				height: plotHeight,
 				plugins: [touchZoomPlugin()],
 				cursor: {
-					sync: { key: SYNC_KEY, setSeries: true },
+					// Only cross-sync the cursor among plots sharing the time axis.
+					sync: timeSynced ? { key: SYNC_KEY, setSeries: false } : undefined,
 					drag: { x: true, y: false, setScale: true },
 				},
 				scales: {
@@ -133,7 +180,8 @@
 				hooks: {
 					setScale: [
 						(u: uPlot, scaleKey: string) => {
-							if (scaleKey !== 'x' || settingScale) return;
+							// Non-time plots must not write into the shared seconds range.
+							if (scaleKey !== 'x' || settingScale || !timeSynced) return;
 							const min = u.scales.x.min;
 							const max = u.scales.x.max;
 							if (min != null && max != null) {
@@ -143,6 +191,7 @@
 					],
 					setCursor: [
 						(u: uPlot) => {
+							if (!timeSynced) return; // don't broadcast a non-time x as the shared cursor
 							const idx = u.cursor.idx;
 							if (idx != null && data[0]) {
 								cursorTimestamp.set(data[0][idx]);
@@ -152,9 +201,9 @@
 				},
 				series: [
 					{}, // x-axis series
-					...fields.map((field: string, i: number) => ({
-						label: field,
-						stroke: colors[i] ?? '#818cf8',
+					...labels.map((label: string, i: number) => ({
+						label,
+						stroke: colors[i],
 						width: 1.5,
 					})),
 				],
@@ -226,17 +275,15 @@
 		}
 
 		// Initial load
-		loadAndRender(config.fields, config.colors);
+		loadAndRender();
 	});
 
-	// React to config.fields changes (when user adds/removes a field in an existing topic)
+	// Re-render when the plot's definition changes: fields for timeseries
+	// plots, or the SQL text for SQL plots.
 	$effect(() => {
-		const fields = config.fields;
-		const colors = config.colors;
-		// Only re-render if fields actually changed
-		const key = fields.join(',');
-		if (key !== lastFieldsKey) {
-			loadAndRender(fields, colors);
+		const key = renderKey();
+		if (key !== lastRenderKey) {
+			loadAndRender();
 		}
 	});
 
@@ -245,6 +292,7 @@
 	$effect(() => {
 		const range = $timeRange;
 		if (!uplot || settingScale) return;
+		if (range && !timeSynced) return;
 
 		if (!isVisible) {
 			// Stash for later — will be applied when plot scrolls into view
@@ -329,19 +377,28 @@
 				</div>
 			{/if}
 			<span class="text-xs sm:text-sm font-medium text-gray-900">{config.yLabel && config.yLabel !== config.topic ? config.yLabel : config.topic}</span>
-			{#if config.yLabel && config.yLabel !== config.topic}
+			{#if config.kind === 'sql'}
+				<span class="text-[10px] font-medium text-indigo-500 bg-indigo-50 rounded px-1.5 py-0.5">SQL</span>
+			{:else if config.yLabel && config.yLabel !== config.topic}
 				<span class="text-[10px] text-gray-400">{config.topic}</span>
 			{/if}
 			<div class="flex flex-wrap items-center gap-x-1.5 sm:gap-x-3 gap-y-1 text-xs">
-				{#each config.fields as field, i}
+				{#each seriesLabels as label, i}
 					<span class="flex items-center gap-1.5">
-						<span class="w-3 h-0.5 rounded" style="background-color: {config.colors[i] ?? '#818cf8'};"></span>
-						<span class="text-gray-500">{field}</span>
+						<span class="w-3 h-0.5 rounded" style="background-color: {seriesColors[i]};"></span>
+						<span class="text-gray-500">{label}</span>
 					</span>
 				{/each}
 			</div>
 		</div>
 		<div class="flex items-center gap-1">
+			{#if config.kind === 'sql'}
+				<button class="text-gray-400 hover:text-indigo-600" onclick={editSql} aria-label="Edit SQL">
+					<svg class="size-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zM19.5 7.125L16.875 4.5" />
+					</svg>
+				</button>
+			{/if}
 			<button class="text-gray-400 hover:text-gray-600" onclick={downloadPng} aria-label="Download as PNG">
 				<svg class="size-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
 					<path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12M12 16.5V3" />

--- a/frontend/src/lib/plots/__tests__/defaultSqlPlots.test.ts
+++ b/frontend/src/lib/plots/__tests__/defaultSqlPlots.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest';
+import type { PlotConfig } from '$lib/types';
+import {
+  DEFAULT_SQL_PLOTS,
+  buildDefaultSqlPlots,
+  reconcileDefaultSqlPlots,
+} from '../defaultSqlPlots';
+
+// Static lint of the registry: keeps entries portable across logs and
+// catches known SQL pitfalls without executing anything.
+describe('DEFAULT_SQL_PLOTS registry lint', () => {
+  it('has unique, stable, prefixed ids', () => {
+    const ids = DEFAULT_SQL_PLOTS.map((d) => d.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) {
+      expect(id).toMatch(/^sql_[a-z0-9_]+$/);
+      // No collision with scratch-plot ids (`sql_<Date.now()>_<n>`).
+      expect(id).not.toMatch(/^sql_\d/);
+    }
+  });
+
+  it('declares non-empty requires', () => {
+    for (const d of DEFAULT_SQL_PLOTS) {
+      expect(d.requires.length, d.id).toBeGreaterThan(0);
+      expect(new Set(d.requires).size, d.id).toBe(d.requires.length);
+    }
+  });
+
+  it('is a single SELECT/WITH statement', () => {
+    for (const d of DEFAULT_SQL_PLOTS) {
+      const sql = d.sql.trim();
+      expect(sql, d.id).toMatch(/^(select|with)\b/i);
+      // No statement separator (a single trailing one would also be cruft).
+      expect(sql, d.id).not.toContain(';');
+    }
+  });
+
+  it('never hardcodes a log-specific data URL', () => {
+    for (const d of DEFAULT_SQL_PLOTS) {
+      expect(d.sql, d.id).not.toMatch(/\/api\/logs\//);
+      expect(d.sql, d.id).not.toMatch(/https?:\/\//);
+    }
+  });
+
+  it('references topics only by name, all covered by requires', () => {
+    for (const d of DEFAULT_SQL_PLOTS) {
+      const refs = [...d.sql.matchAll(/read_parquet\('([^']+)'\)/g)].map((m) => m[1]);
+      expect(refs.length, `${d.id}: SQL must read at least one topic`).toBeGreaterThan(0);
+      for (const ref of refs) {
+        // Accept 'name', 'name.parquet', and instance suffixes ('name_1').
+        const topic = ref.replace(/\.parquet$/, '').replace(/_\d+$/, '');
+        expect(d.requires, `${d.id}: '${ref}' not covered by requires`).toContain(topic);
+      }
+      for (const topic of d.requires) {
+        expect(
+          refs.some((r) => r.replace(/\.parquet$/, '').replace(/_\d+$/, '') === topic),
+          `${d.id}: requires '${topic}' but the SQL never reads it`
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('never equality-joins on timestamp (use ASOF JOIN across topics)', () => {
+    for (const d of DEFAULT_SQL_PLOTS) {
+      const hasPlainJoin = /(?<!asof\s)\bjoin\b/i.test(d.sql);
+      const joinsOnTimestampEquality = /\bon\b[^()]*"?timestamp"?\s*=/i.test(d.sql);
+      expect(
+        hasPlainJoin && joinsOnTimestampEquality,
+        `${d.id}: plain JOIN ... ON timestamp = — topics sample at different rates; use ASOF JOIN`
+      ).toBe(false);
+    }
+  });
+
+  it('window frames order on a signed cast of timestamp', () => {
+    for (const d of DEFAULT_SQL_PLOTS) {
+      if (!/\bover\b|\bwindow\b/i.test(d.sql)) continue;
+      if (!/\brange\s+between\b/i.test(d.sql)) continue;
+      expect(
+        /cast\s*\(\s*"?timestamp"?\s+as\s+bigint\s*\)/i.test(d.sql),
+        `${d.id}: RANGE frame over raw UINT64 timestamp underflows near t=0 — ORDER BY CAST(timestamp AS BIGINT)`
+      ).toBe(true);
+    }
+  });
+});
+
+function scratchSqlPlot(): PlotConfig {
+  return {
+    id: 'sql_1753430000000_1',
+    topic: '',
+    multiId: 0,
+    fields: [],
+    yLabel: 'My scratch plot',
+    colors: [],
+    kind: 'sql',
+    sql: "SELECT timestamp, x FROM read_parquet('sensor_mag') ORDER BY timestamp",
+  };
+}
+
+function topicPlot(): PlotConfig {
+  return {
+    id: 'accel',
+    topic: 'sensor_combined',
+    multiId: 0,
+    fields: ['accelerometer_m_s2[0]'],
+    yLabel: 'Acceleration (m/s²)',
+    colors: ['#818cf8'],
+  };
+}
+
+const REGISTRY_FIRST = DEFAULT_SQL_PLOTS[0];
+const TOPICS_ALL = new Set(DEFAULT_SQL_PLOTS.flatMap((d) => d.requires));
+const TOPICS_NONE = new Set<string>();
+
+describe('buildDefaultSqlPlots', () => {
+  it('emits a PlotConfig per available registry entry', () => {
+    const plots = buildDefaultSqlPlots(TOPICS_ALL);
+    expect(plots.length).toBe(DEFAULT_SQL_PLOTS.length);
+    const p = plots.find((x) => x.id === REGISTRY_FIRST.id)!;
+    expect(p.kind).toBe('sql');
+    expect(p.sql).toBe(REGISTRY_FIRST.sql);
+    expect(p.yLabel).toBe(REGISTRY_FIRST.yLabel);
+    expect(p.topic).toBe('');
+    expect(p.fields).toEqual([]);
+  });
+
+  it('gates on required topics', () => {
+    expect(buildDefaultSqlPlots(TOPICS_NONE)).toEqual([]);
+  });
+});
+
+describe('reconcileDefaultSqlPlots', () => {
+  it('overwrites a saved registry plot from the repo definition (repo wins)', () => {
+    const stale: PlotConfig = {
+      ...buildDefaultSqlPlots(TOPICS_ALL).find((p) => p.id === REGISTRY_FIRST.id)!,
+      sql: 'SELECT 1 AS timestamp, 2 AS stale',
+      yLabel: 'Stale label',
+      colors: ['#000000'],
+      minimized: true,
+    };
+    const out = reconcileDefaultSqlPlots([stale], TOPICS_ALL);
+    const p = out.find((x) => x.id === REGISTRY_FIRST.id)!;
+    expect(p.sql).toBe(REGISTRY_FIRST.sql);
+    expect(p.yLabel).toBe(REGISTRY_FIRST.yLabel);
+    expect(p.colors).toEqual(REGISTRY_FIRST.colors ?? []);
+    // Layout state is the user's — preserved.
+    expect(p.minimized).toBe(true);
+  });
+
+  it('drops a registry plot the log can no longer satisfy', () => {
+    const saved = buildDefaultSqlPlots(TOPICS_ALL);
+    const out = reconcileDefaultSqlPlots(saved, TOPICS_NONE);
+    expect(out.some((p) => p.id === REGISTRY_FIRST.id)).toBe(false);
+  });
+
+  it('appends registry entries missing from the saved layout', () => {
+    const out = reconcileDefaultSqlPlots([topicPlot()], TOPICS_ALL);
+    expect(out[0].id).toBe('accel');
+    expect(out.some((p) => p.id === REGISTRY_FIRST.id)).toBe(true);
+  });
+
+  it('passes through personal scratch SQL plots and topic plots untouched', () => {
+    const scratch = scratchSqlPlot();
+    const topic = topicPlot();
+    const out = reconcileDefaultSqlPlots([scratch, topic], TOPICS_NONE);
+    expect(out).toEqual([scratch, topic]);
+  });
+
+  it('preserves saved order for present entries', () => {
+    const registry = buildDefaultSqlPlots(TOPICS_ALL).find((p) => p.id === REGISTRY_FIRST.id)!;
+    const out = reconcileDefaultSqlPlots([registry, topicPlot()], TOPICS_ALL);
+    expect(out.map((p) => p.id)).toEqual([REGISTRY_FIRST.id, 'accel', ...DEFAULT_SQL_PLOTS.slice(1).map((d) => d.id)]);
+  });
+});

--- a/frontend/src/lib/plots/defaultSqlPlots.ts
+++ b/frontend/src/lib/plots/defaultSqlPlots.ts
@@ -1,0 +1,92 @@
+import type { PlotConfig } from '$lib/types';
+
+/**
+ * A repo-committed SQL default plot. Definitions live in git, never in
+ * localStorage; the Edit Plots SQL editor is the scratchpad before
+ * committing an entry here. Rules (enforced by defaultSqlPlots.test.ts):
+ * stable `id`; topic names only, no `/api/logs/<id>/...` URLs; `requires`
+ * lists every topic read; `ASOF JOIN` across topics; window frames order on
+ * `CAST(timestamp AS BIGINT)`.
+ */
+export interface DefaultSqlPlot {
+  /** Stable unique id, prefixed `sql_`. Never reuse or rename. */
+  id: string;
+  yLabel: string;
+  /** Result contract: `timestamp` col (µs) = x; other numeric cols = series. */
+  sql: string;
+  /** Topics the SQL reads — availability gate per log. */
+  requires: string[];
+  /** Optional; PlotStrip falls back to its palette. */
+  colors?: string[];
+}
+
+export const DEFAULT_SQL_PLOTS: DefaultSqlPlot[] = [
+  // Roll rate vs setpoint on one plot (Flight Review v1 style) — needs a
+  // cross-topic ASOF JOIN, which field selection can't express.
+  {
+    id: 'sql_roll_rate_tracking',
+    yLabel: 'Roll Rate Tracking (rad/s)',
+    sql:
+      `SELECT v.timestamp,\n` +
+      `       v."xyz[0]" AS roll_rate,\n` +
+      `       s.roll     AS roll_rate_setpoint\n` +
+      `FROM read_parquet('vehicle_angular_velocity') v\n` +
+      `ASOF JOIN read_parquet('vehicle_rates_setpoint') s\n` +
+      `  ON v.timestamp >= s.timestamp\n` +
+      `ORDER BY v.timestamp`,
+    requires: ['vehicle_angular_velocity', 'vehicle_rates_setpoint'],
+    colors: ['#818cf8', '#fbbf24'],
+  },
+];
+
+function makeSqlPlot(def: DefaultSqlPlot): PlotConfig {
+  return {
+    id: def.id,
+    topic: '',
+    multiId: 0,
+    fields: [],
+    yLabel: def.yLabel,
+    colors: def.colors ?? [],
+    kind: 'sql',
+    sql: def.sql,
+  };
+}
+
+function isAvailable(def: DefaultSqlPlot, availableTopics: Set<string>): boolean {
+  return def.requires.every((t) => availableTopics.has(t));
+}
+
+/** Registry plots for a fresh layout, gated on the log's available topics. */
+export function buildDefaultSqlPlots(availableTopics: Set<string>): PlotConfig[] {
+  return DEFAULT_SQL_PLOTS.filter((d) => isAvailable(d, availableTopics)).map(makeSqlPlot);
+}
+
+/**
+ * Reconcile a saved layout with the registry ("repo wins"): matched ids get
+ * their definition from the repo (localStorage keeps only presence/order/
+ * minimized); unsatisfiable entries drop; missing ones append; everything
+ * else passes through.
+ */
+export function reconcileDefaultSqlPlots(
+  plots: PlotConfig[],
+  availableTopics: Set<string>
+): PlotConfig[] {
+  const byId = new Map(DEFAULT_SQL_PLOTS.map((d) => [d.id, d]));
+  const out: PlotConfig[] = [];
+  for (const p of plots) {
+    const def = p.kind === 'sql' ? byId.get(p.id) : undefined;
+    if (!def) {
+      out.push(p);
+      continue;
+    }
+    if (!isAvailable(def, availableTopics)) continue;
+    out.push({ ...p, sql: def.sql, yLabel: def.yLabel, colors: def.colors ?? [] });
+  }
+  const present = new Set(out.map((p) => p.id));
+  for (const def of DEFAULT_SQL_PLOTS) {
+    if (!present.has(def.id) && isAvailable(def, availableTopics)) {
+      out.push(makeSqlPlot(def));
+    }
+  }
+  return out;
+}

--- a/frontend/src/lib/stores/logViewer.ts
+++ b/frontend/src/lib/stores/logViewer.ts
@@ -31,6 +31,10 @@ export function togglePlotMinimized(plotId: string): void {
   );
 }
 
+/** When set, the plot builder opens in "edit" mode for this SQL plot,
+ *  loading its SQL back into the editor. Cleared once consumed. */
+export const editSqlPlot = writable<Pick<PlotConfig, 'id' | 'sql' | 'yLabel'> | null>(null);
+
 export const sidebarCollapsed = writable(false);
 export const activePanel = writable<'plots' | 'map' | 'messages' | 'params'>('plots');
 export const builderOpen = writable(false);

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -223,6 +223,12 @@ export interface PlotConfig {
   minimized?: boolean;
   /** Plot rendering kind. 'timeseries' (default) plots fields vs time;
    *  'xy' is a special trajectory/scatter plot with hardcoded topics;
-   *  'spectrogram' is a PSD heatmap with hardcoded topics. */
-  kind?: 'timeseries' | 'xy' | 'spectrogram';
+   *  'spectrogram' is a PSD heatmap with hardcoded topics;
+   *  'sql' runs raw DuckDB SQL (see `sql`) and plots the result. */
+  kind?: 'timeseries' | 'xy' | 'spectrogram' | 'sql';
+  /** For kind === 'sql': the raw DuckDB SQL to execute. The result's
+   *  `timestamp` column (µs) is the x-axis; remaining numeric columns are
+   *  series. Topics are queryable by name
+   *  (e.g. `FROM read_parquet('sensor_mag')`). */
+  sql?: string;
 }

--- a/frontend/src/lib/utils/__tests__/duckdb.test.ts
+++ b/frontend/src/lib/utils/__tests__/duckdb.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { buildParquetUrl, microsToSeconds } from '../duckdb';
+import { describe, it, expect } from 'vitest';
+import { buildParquetUrl, microsToSeconds, resolveTopicRefs } from '../duckdb';
 
 describe('buildParquetUrl', () => {
   it('builds URL for single-instance topic (multiId=0)', () => {
@@ -55,6 +55,59 @@ describe('microsToSeconds', () => {
     const result = microsToSeconds(fakeCol);
     expect(result[0]).toBeCloseTo(5.0);
     expect(result[1]).toBeCloseTo(10.0);
+  });
+});
+
+describe('resolveTopicRefs', () => {
+  const base = '/api/logs/log-a/data';
+  const url = (f: string) => `${window.location.origin}${base}/${f}`;
+
+  it('resolves a bare topic name', () => {
+    expect(resolveTopicRefs("SELECT * FROM read_parquet('sensor_mag')", base)).toBe(
+      `SELECT * FROM read_parquet('${url('sensor_mag.parquet')}')`
+    );
+  });
+
+  it('resolves a .parquet-suffixed name to the same URL', () => {
+    expect(resolveTopicRefs("FROM read_parquet('sensor_mag.parquet')", base)).toBe(
+      `FROM read_parquet('${url('sensor_mag.parquet')}')`
+    );
+  });
+
+  it('resolves multi-instance names', () => {
+    expect(resolveTopicRefs("FROM read_parquet('sensor_accel_1')", base)).toBe(
+      `FROM read_parquet('${url('sensor_accel_1.parquet')}')`
+    );
+  });
+
+  it('resolves every reference in a join', () => {
+    const sql =
+      "FROM read_parquet('vehicle_angular_velocity') v " +
+      "ASOF JOIN read_parquet('vehicle_rates_setpoint') s ON v.timestamp >= s.timestamp";
+    expect(resolveTopicRefs(sql, base)).toBe(
+      `FROM read_parquet('${url('vehicle_angular_velocity.parquet')}') v ` +
+        `ASOF JOIN read_parquet('${url('vehicle_rates_setpoint.parquet')}') s ON v.timestamp >= s.timestamp`
+    );
+  });
+
+  it('tolerates whitespace inside the call', () => {
+    expect(resolveTopicRefs("read_parquet( 'cpuload' )", base)).toBe(
+      `read_parquet('${url('cpuload.parquet')}')`
+    );
+  });
+
+  it('leaves absolute paths and URLs untouched', () => {
+    for (const ref of [
+      "read_parquet('/api/logs/other/data/sensor_mag.parquet')",
+      "read_parquet('https://example.com/x.parquet')",
+    ]) {
+      expect(resolveTopicRefs(ref, base)).toBe(ref);
+    }
+  });
+
+  it('leaves non-read_parquet SQL untouched', () => {
+    const sql = "SELECT 'sensor_mag' AS label, timestamp FROM read_json('x')";
+    expect(resolveTopicRefs(sql, base)).toBe(sql);
   });
 });
 

--- a/frontend/src/lib/utils/duckdb.ts
+++ b/frontend/src/lib/utils/duckdb.ts
@@ -1,5 +1,16 @@
 import type { AsyncDuckDB, AsyncDuckDBConnection, DuckDBBundles } from '@duckdb/duckdb-wasm';
 
+/**
+ * Plottable (numeric) result columns, by declared type rather than values —
+ * robust for computed/aliased and all-null columns. Matches stable Arrow
+ * type ids (no apache-arrow import): Int=2, Float=3, Bool=6, Decimal=7.
+ */
+const NUMERIC_ARROW_TYPE_IDS = new Set<number>([2, 3, 6, 7]);
+
+function isNumericField(field: { typeId: number }): boolean {
+  return NUMERIC_ARROW_TYPE_IDS.has(field.typeId);
+}
+
 let dbInstance: AsyncDuckDB | null = null;
 
 // Same-origin bundle map. Files are served from /duckdb/* — by the Vite dev
@@ -74,6 +85,18 @@ function columnToFloat64(col: { length: number; get(i: number): unknown }): Floa
     out[i] = Number(col.get(i));
   }
   return out;
+}
+
+/**
+ * Resolve bare topic refs — `read_parquet('sensor_mag')` or
+ * `('sensor_mag.parquet')` — to the log's absolute Parquet URL, keeping raw
+ * SQL log-agnostic. Full URLs/paths pass through. Exported for testability.
+ */
+export function resolveTopicRefs(sql: string, baseUrl: string): string {
+  return sql.replace(
+    /read_parquet\(\s*'([A-Za-z_][A-Za-z0-9_]*)(?:\.parquet)?'\s*\)/g,
+    (_m, stem) => `read_parquet('${window.location.origin}${baseUrl}/${stem}.parquet')`
+  );
 }
 
 export class LogSession {
@@ -158,6 +181,63 @@ export class LogSession {
       console.error(`Schema query failed for ${topic}:`, e);
       return [];
     }
+  }
+
+  /**
+   * Run arbitrary SQL (body unrestricted; topic refs resolved by
+   * `resolveTopicRefs`, `timestamp` stays UINT64 — cast it for window
+   * frames). Only the result columns follow a chart contract: x = the
+   * `timestamp` column (µs→s) or else the first column, which must be
+   * numeric; every other numeric column is a series labelled by name,
+   * non-numeric columns are skipped. Returns null on zero rows; throws
+   * DuckDB/shape errors for the caller to surface.
+   */
+  async querySql(
+    sql: string
+  ): Promise<{ x: Float64Array; series: Float64Array[]; labels: string[]; xIsTime: boolean } | null> {
+    const conn = await this.getConnection();
+    const result = await conn.query(resolveTopicRefs(sql, this.baseUrl));
+    if (result.numRows === 0) return null;
+
+    const fields = result.schema.fields as Array<{ name: string; typeId: number; type: unknown }>;
+    if (fields.length < 2) {
+      throw new Error('Query must return at least 2 columns: an x-axis column plus one or more series.');
+    }
+
+    const tsIdx = fields.findIndex((f) => f.name === 'timestamp');
+    const xIdx = tsIdx >= 0 ? tsIdx : 0;
+    const xField = fields[xIdx];
+    if (!isNumericField(xField)) {
+      throw new Error(
+        `x-axis column "${xField.name}" is not numeric (${String(xField.type)}). ` +
+          `Put a numeric column first, or name your time column "timestamp".`
+      );
+    }
+    // Index-based access throughout: name lookups return the first match, so
+    // duplicate column names (common in joins) would alias the wrong data.
+    const xCol = result.getChildAt(xIdx);
+    if (!xCol) {
+      throw new Error(`Failed to read x-axis column "${xField.name}" from the result.`);
+    }
+    // Only a column literally named `timestamp` joins the shared time axis /
+    // cross-plot sync; any other x would corrupt the shared seconds range.
+    const xIsTime = xField.name === 'timestamp';
+    const x = xIsTime ? microsToSeconds(xCol) : columnToFloat64(xCol);
+
+    const series: Float64Array[] = [];
+    const labels: string[] = [];
+    fields.forEach((field, i) => {
+      if (i === xIdx) return;
+      if (!isNumericField(field)) return;
+      const col = result.getChildAt(i);
+      if (!col) return;
+      series.push(columnToFloat64(col));
+      labels.push(field.name);
+    });
+    if (series.length === 0) {
+      throw new Error('Query returned no numeric columns to plot beyond the x-axis.');
+    }
+    return { x, series, labels, xIsTime };
   }
 
   close(): void {

--- a/frontend/src/routes/log/[id]/+page.svelte
+++ b/frontend/src/routes/log/[id]/+page.svelte
@@ -3,6 +3,7 @@
 	import type { FlightMetadata, PlotConfig } from '$lib/types';
 	import { activePlots } from '$lib/stores/logViewer';
 	import { savePlotLayout, loadPlotLayout } from '$lib/utils/plotPersistence';
+	import { buildDefaultSqlPlots, reconcileDefaultSqlPlots } from '$lib/plots/defaultSqlPlots';
 	import DragDropPlotList from '$lib/components/viewer/DragDropPlotList.svelte';
 
 	const ctx = getContext<{ metadata: FlightMetadata; logId: string }>('log-viewer');
@@ -123,6 +124,9 @@
 			plots.push(makeAccelSpectrogramPlot());
 		}
 
+		// Repo-committed SQL plots last, gated on the topics each query requires.
+		plots.push(...buildDefaultSqlPlots(availableTopics));
+
 		return plots;
 	}
 
@@ -134,7 +138,11 @@
 			const saved = loadPlotLayout(ctx.logId);
 			const availableTopics = new Set(Object.keys(ctx.metadata.topics));
 			if (saved && saved.length > 0) {
-				const valid = saved.filter((p) => availableTopics.has(p.topic));
+				// Drop timeseries plots whose topic is gone; sql/xy/spectrogram don't
+				// map to a single topic and error visibly at query time instead.
+				const valid = saved.filter(
+					(p) => (p.kind && p.kind !== 'timeseries') || availableTopics.has(p.topic)
+				);
 				if (valid.length > 0) {
 					// Prepend the trajectory plot if missing from saved layout (so existing
 					// users pick up the new default the first time they reopen a log).
@@ -151,7 +159,9 @@
 					) {
 						valid.push(makeAccelSpectrogramPlot());
 					}
-					activePlots.set(valid);
+					// Registry SQL plots: repo definitions overwrite saved copies;
+					// new entries are appended.
+					activePlots.set(reconcileDefaultSqlPlots(valid, availableTopics));
 				} else {
 					activePlots.set(buildDefaultPlots(ctx.metadata));
 				}


### PR DESCRIPTION
## Custom SQL plots (DuckDB)

We're starting using Flight Review RS in our factory (+ VMU calibration) processes and started experimenting with a heavier lift SQL plot variant to unlock some more involved time series plots.

This PR adds a `sql` plot kind: raw DuckDB SQL over a log's Parquet topics, rendered through the existing uPlot pipeline. Field selection can't express derived or cross-topic analyses (e.g. rate vs. setpoint on one plot). Frontend-only; existing logs work as-is.

- **Authoring** in the existing Edit Plots panel: SQL editor, insertable example, edit-in-place.
- **Topics by name**: `read_parquet('sensor_mag')` — a stateless query-time rewrite resolves names to the log's Parquet URLs, same addressing as generated queries.
- **Result-shape contract**: a `timestamp` column (µs) becomes the shared x-axis + cross-plot sync; other numeric columns become series. Errors surface on the plot card.
- **Repo-committed defaults** (`defaultSqlPlots.ts`): SQL plots defined in git, injected per log when their `requires` topics exist; saved layouts rehydrate definitions from the repo. Ships one `ASOF JOIN` example (roll rate vs. setpoint).
- **Tests**: query-util units + a static lint over the registry (portable names, single SELECT, ASOF rule, signed-cast window frames).

Note: ULog timestamps are UINT64, so window frames must `ORDER BY CAST(timestamp AS BIGINT)`. Documented in the editor hint and enforced for registry entries.

**Examples of the SQL Plot editor and the new additive plot:**

<img width="319" height="915" alt="Screenshot 2026-07-28 at 21 23 04" src="https://github.com/user-attachments/assets/684303b5-1434-4ed3-8d05-dbd2ace676be" />

<img width="1660" height="390" alt="Screenshot 2026-07-28 at 21 23 16" src="https://github.com/user-attachments/assets/ed671cf4-3b67-42a8-a650-0de701d5d354" />

## Possible future direction: Field Plots as generated SQL

Builds on this PR.

Every field plot is already a fixed-template query eg. `SELECT timestamp, "xyz[0]", "xyz[1]" FROM read_parquet('vehicle_angular_velocity') ORDER BY timestamp` - so the topic/field picker can be reframed as a SQL *generator*: ticking fields writes SQL into the same `kind: 'sql'` config, and `queryTopic` (plus the trajectory/spectrogram data paths) collapses into `querySql` as the single query engine. The picker stays the primary UX. "Edit as SQL" becomes a free escape hatch from any plot into the editor (add a moving average, join a setpoint ala Plot Juggler), unifying presets, defaults, and ad-hoc plots into one pipeline.